### PR TITLE
Potential fix for code scanning alert no. 163: Incomplete string escaping or encoding

### DIFF
--- a/Sample.Hosted/wwwroot/lib/onmount/onmount.js
+++ b/Sample.Hosted/wwwroot/lib/onmount/onmount.js
@@ -186,7 +186,7 @@ void (function (root, factory) {
 
     onmount.selectify = function selectify (selector) {
         if (selector[0] === '@') {
-            return '[role~="' + selector.substr(1).replace(/"/g, '\\"') + '"]'
+            return '[role~="' + selector.substr(1).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"]'
         }
         return selector
     }


### PR DESCRIPTION
Potential fix for [https://github.com/duranserkan/DRN-Project/security/code-scanning/163](https://github.com/duranserkan/DRN-Project/security/code-scanning/163)

To fix the issue, we need to ensure that backslashes in the input string are properly escaped. This can be achieved by adding a `replace` call to escape backslashes before escaping double quotes. Specifically:
1. Use a regular expression with the `g` flag to replace all occurrences of backslashes (`\`) with double backslashes (`\\`).
2. Chain this with the existing `replace` call for escaping double quotes.

The updated code will ensure that both backslashes and double quotes are properly escaped, making the function robust against malformed or unsafe input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
