### PR TITLE
refactor(Utils): rename IsDevEnvironment and split AutoMigrate

### DIFF
--- a/.agent/skills/drn-testing/SKILL.md
+++ b/.agent/skills/drn-testing/SKILL.md
@@ -166,6 +166,23 @@ roundTripped.Name.Should().Be("test");
 | `[FactDebuggerOnly]` | - | Run only when debugger attached |
 | `[TheoryDebuggerOnly]` | - | Theory only when debugger attached |
 
+### Test Consolidation
+
+When multiple cases share identical test bodies, prefer one `[Theory]` with multiple data rows over separate methods:
+
+```csharp
+[Theory]
+[DataInlineUnit(2, 3, 5)]     // positive
+[DataInlineUnit(-1, -2, -3)]  // negative
+[DataInlineUnit(0, 0, 0)]     // zeros
+public void Add_Should_Return_Correct_Sum(DrnTestContextUnit context, int a, int b, int expected)
+{
+    new Calculator().Add(a, b).Should().Be(expected);
+}
+```
+
+Last param = expected result · Name covers the dimension · Comment non-obvious rows · Don't consolidate when test bodies differ.
+
 ---
 
 ## Providers

--- a/.agent/skills/test-unit/SKILL.md
+++ b/.agent/skills/test-unit/SKILL.md
@@ -40,18 +40,25 @@ public void Service_Should_DoExpectedBehavior(DrnTestContextUnit context, IDepen
 }
 ```
 
-### Parameterized Tests
+### Parameterized Test Consolidation
+
+When multiple cases share identical test bodies, consolidate into one `[Theory]` with multiple `[DataInlineUnit]` rows:
 
 ```csharp
+// Anti-pattern: separate methods for each case with identical bodies
+// Preferred: single parameterized method
 [Theory]
-[DataInlineUnit(1, "first")]
-[DataInlineUnit(2, "second")]
-public void Test_Multiple_Cases(DrnTestContextUnit context, int id, string name)
+[DataInlineUnit(2, 3, 5)]     // positive + positive
+[DataInlineUnit(-1, -2, -3)]  // negative + negative
+[DataInlineUnit(0, 0, 0)]     // zeros
+public void Add_Should_Return_Correct_Sum(DrnTestContextUnit context, int a, int b, int expected)
 {
-    id.Should().BePositive();
-    name.Should().NotBeEmpty();
+    var calc = new Calculator();
+    calc.Add(a, b).Should().Be(expected);
 }
 ```
+
+**Rules**: Last param = expected result · Name covers the dimension, not one case · Comment rows when values aren't obvious · Don't consolidate when test bodies differ structurally.
 
 ### Exception Testing
 

--- a/AGENTS.LessonsLearned.md
+++ b/AGENTS.LessonsLearned.md
@@ -1,0 +1,68 @@
+# Lessons Learned
+
+## 1. DTT Data Attributes — Parameterized Testing with `DataInline` / `DataInlineUnit`
+
+### How DTT Data Attributes Work
+
+All DTT data attributes (`DataInline`, `DataMember`, `DataSelf` and their `Unit` variants) share identical parameter-resolution behavior:
+
+| Step | What Happens |
+|------|-------------|
+| 1. Context | `DrnTestContext` or `DrnTestContextUnit` auto-provided as first parameter when the method signature requests it |
+| 2. Inline values | Attribute arguments mapped to subsequent method parameters in order |
+| 3. AutoFixture | Remaining parameters without inline values auto-generated (primitives, `Guid`, POCOs, etc.) |
+| 4. NSubstitute | Interface/abstract-class parameters auto-mocked; mocks auto-replace matching registrations in `ServiceCollection` |
+
+### Attribute Variants
+
+| Integration Test | Unit Test | Context Provided |
+|-----------------|-----------|-----------------|
+| `[DataInline]` | `[DataInlineUnit]` | `DrnTestContext` / `DrnTestContextUnit` |
+| `[DataMember]` | `[DataMemberUnit]` | Same as above |
+| `[DataSelf]` | `[DataSelfUnit]` | Same as above |
+
+`DrnTestContextUnit` is lightweight (no `ContainerContext`, `ApplicationContext`, or `FlurlHttpTest`).
+
+### Consolidation Pattern
+
+**When**: Logic has discrete input→output permutations and the test body is identical across cases — consolidate into one `[Theory]` with multiple `[DataInline(...)]` / `[DataInlineUnit(...)]` rows.
+
+**Anti-pattern** (5 methods, ~65 lines):
+```csharp
+[Theory]
+[DataInlineUnit]
+public void Migrate_Should_Be_True_In_Dev_When_Enabled(DrnTestContextUnit context) { /* identical body with different config */ }
+
+[Theory]
+[DataInlineUnit]
+public void Migrate_Should_Be_False_In_Dev_When_Disabled(DrnTestContextUnit context) { /* identical body with different config */ }
+// ... 3 more methods
+```
+
+**Preferred** (1 method, ~17 lines):
+```csharp
+[Theory]
+[DataInlineUnit(AppEnvironment.Development, true, false, true)]   // Dev + AutoMigrateDev=on  → migrate
+[DataInlineUnit(AppEnvironment.Development, false, true, false)]  // Dev + AutoMigrateDev=off → no migrate
+[DataInlineUnit(AppEnvironment.Staging, true, false, false)]      // Staging ignores Dev flag
+[DataInlineUnit(AppEnvironment.Staging, false, true, true)]       // Staging + AutoMigrateStaging=on → migrate
+[DataInlineUnit(AppEnvironment.Production, true, true, false)]    // Production → never migrate
+public void Migrate_Flag_Should_Reflect_Environment_And_AutoMigrate_Settings(DrnTestContextUnit context,
+    AppEnvironment environment, bool autoMigrateDevelopment, bool autoMigrateStaging, bool migrationEnabled)
+{
+    ConfigureEnvironment(context, environment, autoMigrateDevelopment, autoMigrateStaging);
+    var status = context.GetRequiredService<DevelopmentStatus>();
+    var model = CreateChangeModel();
+    status.AddChangeModel(model);
+    model.Flags.Migrate.Should().Be(migrationEnabled);
+}
+```
+
+### Rules
+
+1. **Last parameter = expected result** — each `[DataInlineUnit]` row is a self-contained specification
+2. **Name covers the dimension** — e.g., `..._Should_Reflect_Environment_And_AutoMigrate_Settings`, not a name tied to one specific case
+3. **Comment inline data** — trailing comment on each attribute row when values aren't self-explanatory
+4. **Extract shared setup** — private helper keeps the test body focused on act + assert
+5. **Omit inline values for auto-generated params** — let AutoFixture/NSubstitute handle params you don't need to control
+6. **Don't consolidate when** — test bodies differ structurally, require different setup/teardown, or separate failure messages aid debugging more than parameterization

--- a/AGENTS.LessonsLearned.md
+++ b/AGENTS.LessonsLearned.md
@@ -28,6 +28,7 @@ All DTT data attributes (`DataInline`, `DataMember`, `DataSelf` and their `Unit`
 **When**: Logic has discrete input→output permutations and the test body is identical across cases — consolidate into one `[Theory]` with multiple `[DataInline(...)]` / `[DataInlineUnit(...)]` rows.
 
 **Anti-pattern** (5 methods, ~65 lines):
+
 ```csharp
 [Theory]
 [DataInlineUnit]
@@ -40,6 +41,7 @@ public void Migrate_Should_Be_False_In_Dev_When_Disabled(DrnTestContextUnit cont
 ```
 
 **Preferred** (1 method, ~17 lines):
+
 ```csharp
 [Theory]
 [DataInlineUnit(AppEnvironment.Development, true, false, true)]   // Dev + AutoMigrateDev=on  → migrate

--- a/DRN.Framework.EntityFramework/Context/DrnContextDevelopmentConnection.cs
+++ b/DRN.Framework.EntityFramework/Context/DrnContextDevelopmentConnection.cs
@@ -28,7 +28,7 @@ public static class DrnContextDevelopmentConnection
             return connectionString;
 
         var exceptionMessage = $"Connection string for '{name}' not found.";
-        if (appSettings.IsDevEnvironment)
+        if (appSettings.IsDevelopmentEnvironment)
             exceptionMessage += " Ensure the app is compiled in debug mode when using Postgres in Dev Environment with Test Containers.";
 
         throw ExceptionFor.Configuration(exceptionMessage);

--- a/DRN.Framework.EntityFramework/README.md
+++ b/DRN.Framework.EntityFramework/README.md
@@ -850,6 +850,32 @@ flowchart TD
 > [!CAUTION]
 > `postgres-password` and all `DrnContext_Dev*` settings are **ignored** in non-Development environments. Missing connection strings will throw `ConfigurationException`.
 
+#### Staging
+
+Staging uses the same `GetRequiredConnectionString` flow as Production — explicit connection strings are required.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `IsStagingEnvironment` | `false` | `true` when `Environment=Staging` |
+| `AutoMigrateStaging` | `false` | Enables automatic migrations in staging |
+
+**Example** `appsettings.Staging.json`:
+
+```json
+{
+  "Environment": "Staging",
+  "ConnectionStrings": {
+    "QAContext": "Host=staging-db;Port=5432;Database=qa_staging;User ID=qa_user;Password=***;..."
+  },
+  "DrnDevelopmentSettings": {
+    "AutoMigrateStaging": true
+  }
+}
+```
+
+> [!IMPORTANT]
+> **AutoMigrateDevelopment vs AutoMigrateStaging**: `AutoMigrateDevelopment` defaults to `true` for frictionless local development. `AutoMigrateStaging` defaults to `false` for safe deployments — enable it explicitly for controlled staging migrations. For production-like staging, prefer CI/CD-managed migrations with rollback support.
+
 ---
 
 ### Local Debug with LaunchExternalDependencies
@@ -923,7 +949,7 @@ services:
       - Environment=Development
       - postgres-password=dev-password # Source: DbContextConventions
       - DrnContext_DevHost=postgres    # Source: DbContextConventions
-      - DrnDevelopmentSettings:AutoMigrate=true
+      - DrnDevelopmentSettings:AutoMigrateDevelopment=true
     depends_on:
       - postgres
       
@@ -952,7 +978,7 @@ metadata:
 data:
   Environment: "Development"
   DrnContext_DevHost: "postgres-service" # Source: DbContextConventions
-  DrnDevelopmentSettings:AutoMigrate: "true"
+  DrnDevelopmentSettings:AutoMigrateDevelopment: "true"
 ---
 apiVersion: v1
 kind: Secret
@@ -1014,7 +1040,8 @@ These settings are used **only** by [DrnContextDevelopmentConnection](Context/Dr
 
 | Setting | Default | Source | Purpose |
 |---------|---------|--------|---------|
-| `AutoMigrate` | `false` | DrnDevelopmentSettings.AutoMigrate | Enables migration flow |
+| `AutoMigrateDevelopment` | `true` | DrnDevelopmentSettings.AutoMigrateDevelopment | Auto-migrate in Development |
+| `AutoMigrateStaging` | `false` | DrnDevelopmentSettings.AutoMigrateStaging | Auto-migrate in Staging |
 | `Prototype` | `false` | DrnDevelopmentSettings.Prototype | Enables DB recreation on model changes |
 | `LaunchExternalDependencies` | `false` | DrnDevelopmentSettings.LaunchExternalDependencies | Launches Testcontainers |
 | `TemporaryApplication` | `false` | DrnDevelopmentSettings.TemporaryApplication | **Auto-set by tests** to prevent collision |
@@ -1049,7 +1076,8 @@ public class DrnDevelopmentSettings
     public bool SkipValidation { get; init; }
     public bool TemporaryApplication { get; init; }
     public bool LaunchExternalDependencies { get; init; }
-    public bool AutoMigrate { get; init; }
+    public bool AutoMigrateDevelopment { get; init; } = true;
+    public bool AutoMigrateStaging { get; init; } = false;
     public bool Prototype { get; init; }
 }
 ```

--- a/DRN.Framework.EntityFramework/README.md
+++ b/DRN.Framework.EntityFramework/README.md
@@ -250,7 +250,7 @@ public class User : SourceKnownEntity
 *   **Scope Check**: Validates that 50+ service scopes can be created rapidly (catches singleton/scoped mismatches early).
 *   **Entity Type Check**: Scans all `SourceKnownEntity` types in the model to ensure they have unique `[EntityType]` attributes.
 *   **Auto-Migration & Seeding**:
-    *   Detects pending migrations and applies them if configured (`DrnDevelopmentSettings:AutoMigrate`).
+    *   Detects pending migrations and applies them if configured (`DrnDevelopmentSettings:AutoMigrateDevelopment`).
     *   Runs `SeedAsync` implementations from registered `NpgsqlDbContextOptionsAttribute`s after migration.
 
 ### Example
@@ -696,7 +696,7 @@ public class MyDbContext : DrnContext<MyDbContext> { }
 {
   "DrnDevelopmentSettings": {
     "LaunchExternalDependencies": true,  // Uses testcontainer instead of connection string
-    "AutoMigrate": true,                 // Required for schema initialization
+    "AutoMigrateDevelopment": true,      // Required for schema initialization
     "Prototype": true                    // Enables database recreation on model changes
   }
 }
@@ -896,7 +896,7 @@ public class SampleProgramActions : DrnProgramActions
   "Environment": "Development",
   "DrnDevelopmentSettings": {
     "LaunchExternalDependencies": true,
-    "AutoMigrate": true,
+    "AutoMigrateDevelopment": true,
     "Prototype": true
   }
 }

--- a/DRN.Framework.EntityFramework/README.md
+++ b/DRN.Framework.EntityFramework/README.md
@@ -1027,7 +1027,7 @@ When using `LaunchExternalDependencies` or `ContainerContext`, these values from
 |----------|---------|-------|
 | `DefaultPassword` | `"drn"` | Container password |
 | `DefaultImage` | `"postgres"` | Docker image |
-| `DefaultVersion` | `"18.1-alpine3.23"` | Image tag |
+| `DefaultVersion` | `"18.3-alpine3.23"` | Image tag |
 | `Database` | `"drn"` | From `DbContextConventions.DefaultDatabase` |
 | `Username` | `"drn"` | From `DbContextConventions.DefaultUsername` |
 

--- a/DRN.Framework.EntityFramework/RELEASE-NOTES.md
+++ b/DRN.Framework.EntityFramework/RELEASE-NOTES.md
@@ -32,7 +32,7 @@ My family celebrates the enduring legacy of Mustafa Kemal Atatürk's enlightenme
     *   **Auto-Connection Strings**: Automatically generates connection strings for local Docker containers (e.g., `Host=postgresql;Port=5432...`) if missing.
     *   **Configurable Keys**: Supports overrides via `DrnContext_DevHost`, `DrnContext_DevUsername`, `DrnContext_DevDatabase`.
     *   **Prototype Mode**: Auto-recreates database on model changes when `UsePrototypeMode=true` and `DrnDevelopmentSettings:Prototype=true`.
-    *   **Auto-Migration**: `DrnDevelopmentSettings:AutoMigrate` applies pending migrations at startup.
+    *   **Auto-Migration**: `DrnDevelopmentSettings:AutoMigrateDevelopment` (default `true`) and `AutoMigrateStaging` (default `false`) apply pending migrations per environment at startup.
 
 ---
 

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
@@ -154,7 +154,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
         {
             var (_, applicationBuilder) = await CreateApplicationBuilder(args, appSettings, scopedLog);
             var services = applicationBuilder.Services.BuildServiceProvider();
-            var isDevelopment = services.GetService<IAppSettings>()?.IsDevelopmentEnvironment ?? false;
+            var isDevelopment = appSettings?.IsDevelopmentEnvironment ?? false;
             var handler = services.GetService<IDrnExceptionHandler>();
             if (handler != null && isDevelopment)
             {

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
@@ -118,7 +118,8 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
             scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.SkipValidation)}", appSettings.DevelopmentSettings.SkipValidation);
             scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.TemporaryApplication)}", appSettings.DevelopmentSettings.TemporaryApplication);
             scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.Prototype)}", appSettings.DevelopmentSettings.Prototype);
-            scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.AutoMigrate)}", appSettings.DevelopmentSettings.AutoMigrate);
+            scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.AutoMigrateDevelopment)}", appSettings.DevelopmentSettings.AutoMigrateDevelopment);
+            scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.AutoMigrateStaging)}", appSettings.DevelopmentSettings.AutoMigrateStaging);
             scopedLog.Add($"DrnDevelopmentSettings_{nameof(DrnDevelopmentSettings.LaunchExternalDependencies)}", appSettings.DevelopmentSettings.LaunchExternalDependencies);
             scopedLog.AddToActions("Running Application");
             logger.LogWarning("{@Logs}", scopedLog.Logs);
@@ -153,7 +154,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
         {
             var (_, applicationBuilder) = await CreateApplicationBuilder(args, appSettings, scopedLog);
             var services = applicationBuilder.Services.BuildServiceProvider();
-            var isDevelopment = services.GetService<IAppSettings>()?.IsDevEnvironment ?? false;
+            var isDevelopment = services.GetService<IAppSettings>()?.IsDevelopmentEnvironment ?? false;
             var handler = services.GetService<IDrnExceptionHandler>();
             if (handler != null && isDevelopment)
             {
@@ -193,7 +194,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
         await (actions?.ApplicationBuiltAsync(program, application, appSettings, scopeLog) ?? Task.CompletedTask);
 
         var requestPipelineSummary = application.GetRequestPipelineSummary();
-        if (appSettings.IsDevEnvironment) //todo send application summaries to nexus for auditing, implement application dependency summary as well
+        if (appSettings.IsDevelopmentEnvironment) //todo send application summaries to nexus for auditing, implement application dependency summary as well
             scopeLog.Add(nameof(RequestPipelineSummary), requestPipelineSummary);
 
         program.ValidateEndpoints(application, appSettings);
@@ -342,7 +343,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
                 builder.AddFullscreen().Self();
             });
 
-        if (!appSettings.IsDevEnvironment)
+        if (!appSettings.IsDevelopmentEnvironment)
         {
             //https://hstspreload.org/ preload can be risky
             //What to Do When Your Certificate Fails
@@ -436,7 +437,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
         //https://learn.microsoft.com/en-us/aspnet/core/security/gdpr
         options.HttpOnly = HttpOnlyPolicy.None; //Ensures cookies are accessible via JavaScript, use with strict csp
         options.MinimumSameSitePolicy = SameSiteMode.Strict;
-        options.Secure = appSettings.IsDevEnvironment ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;
+        options.Secure = appSettings.IsDevelopmentEnvironment ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;
 
         options.ConsentCookieValue = ConsentCookie.DefaultValue.Encode();
         // default cookie name(.AspNet.Consent) exposes server
@@ -754,14 +755,14 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
         mvcBuilder.AddControllersAsServices();
         mvcBuilder.AddJsonOptions(options => JsonConventions.SetHtmlSafeWebJsonDefaults(options.JsonSerializerOptions));
 
-        if (appSettings.IsDevEnvironment)
+        if (appSettings.IsDevelopmentEnvironment)
             mvcBuilder.AddRazorRuntimeCompilation();
     }
 
     protected virtual void ConfigureSwaggerOptions(DrnProgramSwaggerOptions options, IAppSettings appSettings)
     {
         options.OpenApiInfo.Title = appSettings.ApplicationName;
-        options.AddSwagger = appSettings.IsDevEnvironment;
+        options.AddSwagger = appSettings.IsDevelopmentEnvironment;
     }
 
     protected virtual void ValidateEndpoints(WebApplication application, IAppSettings appSettings)

--- a/DRN.Framework.Hosting/Middlewares/ExceptionHandler/DrnExceptionHandler.cs
+++ b/DRN.Framework.Hosting/Middlewares/ExceptionHandler/DrnExceptionHandler.cs
@@ -91,7 +91,7 @@ public class DrnExceptionHandler(
         var model = await ExecuteExceptionPageModel(context, exception);
         var result = await GetExceptionContentResult(context, exception, model);
 
-        if (appSettings.IsDevEnvironment && result != null)
+        if (appSettings.IsDevelopmentEnvironment && result != null)
         {
             context.Response.ContentType = result.ContentType;
             await context.Response.WriteAsync(result.Content);
@@ -107,7 +107,7 @@ public class DrnExceptionHandler(
 
     private async Task<ExceptionContentResult?> GetExceptionContentResult(HttpContext context, Exception exception, DrnExceptionModel? model)
     {
-        if (!appSettings.IsDevEnvironment || model == null) return null;
+        if (!appSettings.IsDevelopmentEnvironment || model == null) return null;
 
         //https://learn.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?view=aspnetcore-9.0#database-error-page
         var result = await contentProvider.CreateErrorContentResult(context, exception, model);

--- a/DRN.Framework.Hosting/Middlewares/HttpScopeMiddleware.cs
+++ b/DRN.Framework.Hosting/Middlewares/HttpScopeMiddleware.cs
@@ -27,7 +27,7 @@ public class HttpScopeMiddleware(RequestDelegate next)
             ResponseControls(context);
             PrepareScopeLog(context, scopedLog);
             ScopeContext.Initialize(context.TraceIdentifier, scopedLog, scopedUser, appSettings, serviceProvider);
-            if (ExceptionPageAccessor.IsExceptionPage(context.Request.Path.Value, appSettings.IsDevEnvironment))
+            if (ExceptionPageAccessor.IsExceptionPage(context.Request.Path.Value, appSettings.IsDevelopmentEnvironment))
             {
                 context.Abort(); //Requesting exception pages are malicious. Exception pages are rendered when an exception occurs.
                 return;

--- a/DRN.Framework.Hosting/README.md
+++ b/DRN.Framework.Hosting/README.md
@@ -266,7 +266,7 @@ These hooks define the request processing middleware sequence.
 | Property | Default | Purpose |
 |----------|---------|---------|
 | `AppBuilderType` | `DrnDefaults` | Controls builder creation. Use `Slim` for minimal APIs. |
-| `DrnProgramSwaggerOptions` | (Object) | Toggles Swagger generation. Defaults to `IsDevEnvironment`. |
+| `DrnProgramSwaggerOptions` | (Object) | Toggles Swagger generation. Defaults to `IsDevelopmentEnvironment`. |
 | `NLogOptions` | (Object) | Controls NLog bootstrapping (e.g., replace logger factory). |
 
 ## Configuration

--- a/DRN.Framework.Hosting/RELEASE-NOTES.md
+++ b/DRN.Framework.Hosting/RELEASE-NOTES.md
@@ -21,7 +21,7 @@ My family celebrates the enduring legacy of Mustafa Kemal Atatürk's enlightenme
         *   `ConfigureMvcBuilder` / `ConfigureMvcOptions`: Customize MVC conventions and runtime compilation.
         *   `ConfigureStaticFileOptions` / `ConfigureResponseCachingOptions`: Optimize asset delivery with server-side response caching (16MB max, case-insensitive) and automatic static asset caching.
         *   `ConfigureResponseCompressionOptions` / `ConfigureCompressionProviders`: Brotli and Gzip compression for static assets with built-in BREACH/CRIME protection.
-        *   `ConfigureCookiePolicy`: Centralized security settings for cookies (HttpOnly, Secure, SameSite) with environment-aware defaults.
+        *   `ConfigureCookiePolicy`: Centralized security settings for cookies (HttpOnly, Secure, SameSite) with environment-aware defaults via `IsDevelopmentEnvironment`.
     *   **Pipeline Phase**:
         *   `ConfigureApplicationPipelineStart`: HSTS, Forwarded Headers.
         *   `ConfigureApplicationPreScopeStart`: Static files, caching, and compression.

--- a/DRN.Framework.Testing/Contexts/Postgres/PostgresContainerSettings.cs
+++ b/DRN.Framework.Testing/Contexts/Postgres/PostgresContainerSettings.cs
@@ -5,7 +5,7 @@ namespace DRN.Framework.Testing.Contexts.Postgres;
 public class PostgresContainerSettings
 {
     public static string DefaultImage { get; set; } = "postgres";
-    public static string DefaultVersion { get; set; } = "18.2-alpine3.23";
+    public static string DefaultVersion { get; set; } = "18.3-alpine3.23";
     public static string DefaultPassword { get; set; } = "drn";
 
     public string? Image { get; init; } = DefaultImage;

--- a/DRN.Framework.Testing/Extensions/WebApplicationBuilderExtensions.cs
+++ b/DRN.Framework.Testing/Extensions/WebApplicationBuilderExtensions.cs
@@ -68,7 +68,7 @@ public class ExternalDependencyLaunchResult(IAppSettings appSettings)
     /// </list>
     /// </summary>
     public bool Launch { get; } = !TestEnvironment.DrnTestContextEnabled
-                                  && appSettings.IsDevEnvironment
+                                  && appSettings.IsDevelopmentEnvironment
                                   && appSettings.DevelopmentSettings.LaunchExternalDependencies
                                   && !appSettings.DevelopmentSettings.TemporaryApplication;
 }

--- a/DRN.Framework.Testing/README.md
+++ b/DRN.Framework.Testing/README.md
@@ -427,7 +427,8 @@ Usually set by appsettings.Development.json, environment variables, config maps.
 
 | Setting | Default | Source | Purpose |
 |---------|---------|--------|---------|
-| `DrnDevelopmentSettings:AutoMigrate` | `false` | DrnDevelopmentSettings.AutoMigrate | Enables migration flow |
+| `DrnDevelopmentSettings:AutoMigrateDevelopment` | `true` | DrnDevelopmentSettings.AutoMigrateDevelopment | Auto-migrate in Development |
+| `DrnDevelopmentSettings:AutoMigrateStaging` | `false` | DrnDevelopmentSettings.AutoMigrateStaging | Auto-migrate in Staging |
 | `DrnDevelopmentSettings:Prototype` | `false` | DrnDevelopmentSettings.Prototype | Enable DB recreation on model changes |
 | `DrnDevelopmentSettings:LaunchExternalDependencies` | `false` | DrnDevelopmentSettings.LaunchExternalDependencies | Launch Testcontainers |
 | `DrnDevelopmentSettings:TemporaryApplication` | `false` | DrnDevelopmentSettings.TemporaryApplication | **Auto-set by tests** to prevent collision |
@@ -563,6 +564,60 @@ public void Unit_Test_Example(DrnTestContextUnit context, int value, IMockable m
     service.Max.Should().Be(99);
 }
 ```
+
+### Test Consolidation Pattern
+
+When multiple test cases share identical test bodies and differ only in input/expected-output, consolidate them into a single `[Theory]` with multiple data attribute rows instead of writing separate methods.
+
+**Anti-pattern** — separate methods for each case:
+```csharp
+[Theory]
+[DataInlineUnit]
+public void Add_Should_Return_Positive_Sum(DrnTestContextUnit context)
+{
+    var calc = new Calculator();
+    calc.Add(2, 3).Should().Be(5);
+}
+
+[Theory]
+[DataInlineUnit]
+public void Add_Should_Handle_Negatives(DrnTestContextUnit context)
+{
+    var calc = new Calculator();
+    calc.Add(-1, -2).Should().Be(-3);
+}
+
+[Theory]
+[DataInlineUnit]
+public void Add_Should_Handle_Zero(DrnTestContextUnit context)
+{
+    var calc = new Calculator();
+    calc.Add(0, 0).Should().Be(0);
+}
+```
+
+**Preferred** — one parameterized method covering all permutations:
+```csharp
+[Theory]
+[DataInlineUnit(2, 3, 5)]     // positive + positive
+[DataInlineUnit(-1, -2, -3)]  // negative + negative
+[DataInlineUnit(0, 0, 0)]     // zeros
+[DataInlineUnit(-1, 1, 0)]    // cancellation
+public void Add_Should_Return_Correct_Sum(DrnTestContextUnit context, int a, int b, int expected)
+{
+    var calc = new Calculator();
+    calc.Add(a, b).Should().Be(expected);
+}
+```
+
+**Guidelines**:
+- **Last parameter = expected result** — each attribute row is a self-contained specification
+- **Name covers the dimension** — describes *what* is tested, not a specific case
+- **Comment inline data** — add trailing comments when values aren't self-explanatory
+- **Extract shared setup** — use private helpers to keep the test body focused on act + assert
+- **Omit values for auto-generated params** — let AutoFixture/NSubstitute handle params you don't control
+- **Don't consolidate when** test bodies differ structurally or separate failure messages aid debugging more than parameterization
+
 
 ## DebugOnly Tests
 Following attributes can be used to run test only when the debugger is attached. These attributes does respect the attached debugger, not debug or release configuration.

--- a/DRN.Framework.Testing/README.md
+++ b/DRN.Framework.Testing/README.md
@@ -570,6 +570,7 @@ public void Unit_Test_Example(DrnTestContextUnit context, int value, IMockable m
 When multiple test cases share identical test bodies and differ only in input/expected-output, consolidate them into a single `[Theory]` with multiple data attribute rows instead of writing separate methods.
 
 **Anti-pattern** — separate methods for each case:
+
 ```csharp
 [Theory]
 [DataInlineUnit]
@@ -597,6 +598,7 @@ public void Add_Should_Handle_Zero(DrnTestContextUnit context)
 ```
 
 **Preferred** — one parameterized method covering all permutations:
+
 ```csharp
 [Theory]
 [DataInlineUnit(2, 3, 5)]     // positive + positive

--- a/DRN.Framework.Testing/RELEASE-NOTES.md
+++ b/DRN.Framework.Testing/RELEASE-NOTES.md
@@ -24,7 +24,7 @@ My family celebrates the enduring legacy of Mustafa Kemal Atatürk's enlightenme
     *   **ApplicationContext**: Deep integration with `WebApplicationFactory`.
     *   **Helpers**: `CreateClientAsync` (starts app + migrations + auth client), `CreateApplicationAndBindDependenciesAsync`, `LogToTestOutput`.
 *   **Local Development Experience**
-    *   **Infrastructure Management**: `LaunchExternalDependenciesAsync` for `WebApplicationBuilder` to automatically start containers (Postgres, RabbitMQ) during development, ensuring zero-configuration onboarding for new developers.
+    *   **Infrastructure Management**: `LaunchExternalDependenciesAsync` for `WebApplicationBuilder` to automatically start containers (Postgres, RabbitMQ) when `IsDevelopmentEnvironment` is true, ensuring zero-configuration onboarding for new developers.
 *   **Data Attributes (Auto-Mocking)**
     *   **DataInline**: Replaces `[InlineData]`. Auto-mocks interfaces (NSubstitute), fills missing params (AutoFixture), provides `DrnTestContext`.
     *   **DataMember**: Replaces `[MemberData]`. Source data from properties with auto-mocking support.

--- a/DRN.Framework.Utils/Models/DevelopmentStatus.cs
+++ b/DRN.Framework.Utils/Models/DevelopmentStatus.cs
@@ -12,7 +12,13 @@ public class DevelopmentStatus(IAppSettings appSettings)
 
     internal void AddChangeModel(DbContextChangeModel contextModel)
     {
-        contextModel.Flags.Migrate = appSettings is { IsDevEnvironment: true, DevelopmentSettings.AutoMigrate: true };
+        if (appSettings.IsDevelopmentEnvironment)
+            contextModel.Flags.Migrate = appSettings.DevelopmentSettings.AutoMigrateDevelopment;
+        else if (appSettings.IsStagingEnvironment)
+            contextModel.Flags.Migrate = appSettings.DevelopmentSettings.AutoMigrateStaging;
+        else
+            contextModel.Flags.Migrate = false; // Production: never auto-migrate
+
         contextModel.Flags.DevelopmentSettingsPrototypeFlag = appSettings.DevelopmentSettings.Prototype;
         _contextModels.Add(contextModel);
     }
@@ -34,7 +40,7 @@ public record DbContextChangeModelFlags(bool HasPendingModelChanges, bool Npgsql
         HasPendingMigrations = pendingMigrationCount > 0;
         HasPendingChanges = HasPendingMigrations || HasPendingModelChanges;
         HasPendingChangesForPrototype = (migrationCount == 0 && HasPendingModelChanges) ||
-                                             (migrationCount > 0 && UsePrototypeModeWhenMigrationExists && HasPendingModelChanges);
+                                        (migrationCount > 0 && UsePrototypeModeWhenMigrationExists && HasPendingModelChanges);
 
         HasPendingMigrationsWithoutPendingModelChanges = pendingMigrationCount > 0 && !HasPendingModelChanges;
     }

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -247,7 +247,7 @@ public class MyService(IAppSettings settings)
 {
     public void DoWork()
     {
-        if (settings.IsDevEnvironment) { ... }
+        if (settings.IsDevelopmentEnvironment) { ... }
         
         var conn = settings.GetRequiredConnectionString("Default");
         var value = settings.GetValue<int>("MySettings:Timeout", 30);
@@ -290,7 +290,7 @@ Override the mount directory by registering `IMountedSettingsConventionsOverride
 |---------|-------|----------|
 | `ConfigurationException` on startup | Missing required configuration key | Add the key to `appsettings.json` or environment variables |
 | `GetRequiredConnectionString` throws | Connection string not found | Verify key exists under `ConnectionStrings` section |
-| `IsDevEnvironment` always false | `ASPNETCORE_ENVIRONMENT` not set | Set environment variable or use `launchSettings.json` |
+| `IsDevelopmentEnvironment` always false | `ASPNETCORE_ENVIRONMENT` not set | Set environment variable or use `launchSettings.json` |
 | Mounted settings not loading | Wrong mount path | Verify files exist at `/appconfig/json-settings/` or override via `IMountedSettingsConventionsOverride` |
 | Environment variables not binding | Wrong naming format | Use `__` (double underscore) for nested keys: `MySection__MyKey` |
 

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -247,7 +247,8 @@ public class MyService(IAppSettings settings)
 {
     public void DoWork()
     {
-        if (settings.IsDevelopmentEnvironment) { ... }
+        if (settings.IsDevelopmentEnvironment) { /* dev-only logic */ }
+        if (settings.IsStagingEnvironment) { /* staging-only logic */ }
         
         var conn = settings.GetRequiredConnectionString("Default");
         var value = settings.GetValue<int>("MySettings:Timeout", 30);

--- a/DRN.Framework.Utils/RELEASE-NOTES.md
+++ b/DRN.Framework.Utils/RELEASE-NOTES.md
@@ -16,14 +16,16 @@ My family celebrates the enduring legacy of Mustafa Kemal Atatürk's enlightenme
     *   **Test Helpers**: `ReplaceInstance`, `ReplaceScoped`, `ReplaceTransient`, `ReplaceSingleton` overrides for integration tests.
 *   **Configuration System**
     *   **IAppSettings**: Strong-typed access to config with support for Connection Strings and Sections.
+    *   **Environment Helpers**: `IsDevelopmentEnvironment` and `IsStagingEnvironment` properties for explicit environment checks.
     *   **[Config] Attribute**: Bind classes directly to config sections (e.g., `[Config("Payment")]`). Support for `[ConfigRoot]`.
     *   **Layered Sources**: Loads `appsettings`, `appsettings.{Env}`, User Secrets, Env Vars, and **Mounted Settings** (`/appconfig/json-settings/*.json`, `/appconfig/key-per-file-settings`).
+    *   **Environment-Aware Auto-Migration**: `DrnDevelopmentSettings.AutoMigrateDevelopment` (default `true`) and `AutoMigrateStaging` (default `false`) replace the previous single `AutoMigrate` flag, enabling per-environment migration control.
 *   **Ambient Context & Scoped Cancellation**
     *   **ScopeContext**: Centralized access to `UserId`, `TraceId`, `Authenticated` status, and ambient `IAppSettings`/`IScopedLog`. Built-in RBAC helpers.
     *   **ICancellationUtils**: Scoped cancellation management supporting token merging and lifecycle control.
 *   **Scoped Logging & Diagnostics**
     *   **IScopedLog**: Request aggregation of actions, properties, and exceptions. `Measure()` for performance tracking and counting.
-    *   **DevelopmentStatus**: Runtime tracking of DB model changes and migration status (Dev only).
+    *   **DevelopmentStatus**: Runtime tracking of DB model changes and migration status with environment-aware migration decisions (Development and Staging).
 *   **Advanced Data & Bit Packing**
     *   **Bit Packing**: `NumberBuilder` and `NumberParser` (ref structs) for high-performance custom data structures and bit manipulation.
     *   **Monotonic Pagination**: `IPaginationUtils` for temporal cursor-based pagination leveraging entity IDs.

--- a/DRN.Framework.Utils/Settings/AppSettings.cs
+++ b/DRN.Framework.Utils/Settings/AppSettings.cs
@@ -22,7 +22,8 @@ public interface IAppSettings
     DrnDevelopmentSettings DevelopmentSettings { get; }
     NexusAppSettings NexusAppSettings { get; }
     AppEnvironment Environment { get; }
-    bool IsDevEnvironment { get; }
+    bool IsDevelopmentEnvironment { get; }
+    bool IsStagingEnvironment { get; }
 
     /// <summary>
     ///  Default app key, can be used publicly. For example, to separate development and production data.
@@ -112,7 +113,8 @@ public class AppSettings : IAppSettings
     public NexusAppSettings NexusAppSettings { get; }
     public AppEnvironment Environment { get; }
 
-    public bool IsDevEnvironment => Environment == AppEnvironment.Development;
+    public bool IsDevelopmentEnvironment => Environment == AppEnvironment.Development;
+    public bool IsStagingEnvironment => Environment == AppEnvironment.Staging;
 
     /// <summary>
     ///  Default app key, can be used publicly. For example, to separate development and production data.

--- a/DRN.Framework.Utils/Settings/DrnDevelopmentSettings.cs
+++ b/DRN.Framework.Utils/Settings/DrnDevelopmentSettings.cs
@@ -23,12 +23,17 @@ public class DrnDevelopmentSettings
     public bool LaunchExternalDependencies { get; init; }
 
     /// <summary>
-    /// When true in dev-environment, after registered services validated, database migrations will be applied automatically for rapid application development
+    /// It is true by default, When true in development-environment, after registered services validated, database migrations will be applied automatically for rapid application development
     /// </summary>
-    public bool AutoMigrate { get; init; }
+    public bool AutoMigrateDevelopment { get; init; } = true;
+    
+    /// <summary>
+    /// It is false by default, When true in staging-environment, after registered services validated, database migrations will be applied automatically.
+    /// </summary>
+    public bool AutoMigrateStaging { get; init; } = false;
 
     /// <summary>
-    /// Turns on fast prototyping for database development when <see cref="AutoMigrate"/> is on.
+    /// Turns on fast prototyping for database development when <see cref="AutoMigrateDevelopment"/> is on.
     /// <para>
     /// When true, any DbContext that has <c>NpgsqlDbContextOptionsAttribute.UsePrototypeMode = true</c> will be recreated if there is pending model changes.
     /// </para>

--- a/DRN.Nexus.Hosted/NexusModule.cs
+++ b/DRN.Nexus.Hosted/NexusModule.cs
@@ -17,7 +17,7 @@ public static class NexusModule
             .AddNexusApplicationServices()
             .Configure<FormOptions>(options => options.MultipartBodyLengthLimit = 1000 * 1024) // size limit
             //.ConfigureCookieAuthenticationOptions(settings) //todo: update with nexus implementation
-            .AddIdentityApiEndpoints<NexusUser>(ConfigureIdentity(settings.IsDevEnvironment));
+            .AddIdentityApiEndpoints<NexusUser>(ConfigureIdentity(settings.IsDevelopmentEnvironment));
         //.AddPersonalDataProtection<>() //todo: enable personal data protection
 
         services.AddServicesWithAttributes();

--- a/DRN.Nexus.Hosted/appsettings.Development.json
+++ b/DRN.Nexus.Hosted/appsettings.Development.json
@@ -5,7 +5,6 @@
   },
   "DrnDevelopmentSettings": {
     "Prototype": true,
-    "AutoMigrate": true,
     "LaunchExternalDependencies": true
   }
 }

--- a/DRN.Test.Integration/Tests/Framework/EntityFramework/DrnContextDevelopmentConnectionTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/EntityFramework/DrnContextDevelopmentConnectionTests.cs
@@ -37,7 +37,7 @@ public class DrnContextDevelopmentConnectionTests
 
         var appSettings = testContext.GetRequiredService<IAppSettings>();
         appSettings.GetValue<string>(DbContextConventions.DevPasswordKey).Should().Be(password);
-        appSettings.DevelopmentSettings.AutoMigrateDevelopment.Should().BeTrue();
+        appSettings.DevelopmentSettings.AutoMigrateDevelopment.Should().Be(migrate);
 
         var connectionString = DrnContextDevelopmentConnection.GetConnectionString(appSettings, nameof(QAContext));
         connectionString.Should().NotBeNull();

--- a/DRN.Test.Integration/Tests/Framework/EntityFramework/DrnContextDevelopmentConnectionTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/EntityFramework/DrnContextDevelopmentConnectionTests.cs
@@ -29,7 +29,7 @@ public class DrnContextDevelopmentConnectionTests
             { DbContextConventions.DevPasswordKey, password },
             { DbContextConventions.DevHostKey, csBuilder.Host! },
             { DbContextConventions.DevPortKey, csBuilder.Port },
-            { DrnDevelopmentSettings.GetKey(nameof(DrnDevelopmentSettings.AutoMigrate)), migrate }
+            { DrnDevelopmentSettings.GetKey(nameof(DrnDevelopmentSettings.AutoMigrateDevelopment)), migrate }
         };
 
         testContext.AddToConfiguration(developmentDbSettings);
@@ -37,7 +37,7 @@ public class DrnContextDevelopmentConnectionTests
 
         var appSettings = testContext.GetRequiredService<IAppSettings>();
         appSettings.GetValue<string>(DbContextConventions.DevPasswordKey).Should().Be(password);
-        appSettings.DevelopmentSettings.AutoMigrate.Should().BeTrue();
+        appSettings.DevelopmentSettings.AutoMigrateDevelopment.Should().BeTrue();
 
         var connectionString = DrnContextDevelopmentConnection.GetConnectionString(appSettings, nameof(QAContext));
         connectionString.Should().NotBeNull();

--- a/DRN.Test.Performance/DRN.Test.Performance.csproj
+++ b/DRN.Test.Performance/DRN.Test.Performance.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageReference Include="Blake3" Version="2.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DRN.Test.Unit/Tests/Framework/Hosting/ConfigurationExtensionsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/ConfigurationExtensionsTests.cs
@@ -19,7 +19,8 @@ public class ConfigurationExtensionsTests
         var password = appsettings.GetValue<string>("postgres-password");
         password.Should().Be("Be Always Progressive: Follow the Mustafa Kemal Atatürk's Enlightenment Ideals");
 
-        appsettings.DevelopmentSettings.AutoMigrate.Should().BeTrue();
+        appsettings.DevelopmentSettings.AutoMigrateDevelopment.Should().BeFalse();
+        appsettings.DevelopmentSettings.AutoMigrateStaging.Should().BeTrue();
 
         var summaryJson = appsettings.GetDebugView().ToSummary().Serialize();
         summaryJson.Should().NotBeEmpty();

--- a/DRN.Test.Unit/Tests/Framework/Hosting/MountDir/json-settings/settings-override.json
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/MountDir/json-settings/settings-override.json
@@ -1,7 +1,8 @@
 {
   "Environment": "staging",
   "DrnDevelopmentSettings": {
-    "AutoMigrate": true
+    "AutoMigrateDevelopment": false,
+    "AutoMigrateStaging": true
   },
   "NexusAppSettings": {
     "MacKeys": [

--- a/DRN.Test.Unit/Tests/Framework/Utils/Models/DevelopmentStatusTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Models/DevelopmentStatusTests.cs
@@ -1,0 +1,36 @@
+using DRN.Framework.SharedKernel.Enums;
+using DRN.Framework.Utils.Models;
+
+namespace DRN.Test.Unit.Tests.Framework.Utils.Models;
+
+public class DevelopmentStatusTests
+{
+    private static DbContextChangeModel CreateChangeModel() => new("TestContext", ["Migration1"], ["Migration1"],
+        new DbContextChangeModelFlags(false, false, false));
+
+    private static void ConfigureEnvironment(DrnTestContextUnit context, AppEnvironment environment, bool autoMigrateDevelopment, bool autoMigrateStaging)
+    {
+        var section = nameof(DrnDevelopmentSettings);
+        context.AddToConfiguration("Environment", environment.ToString());
+        context.AddToConfiguration(section, nameof(DrnDevelopmentSettings.AutoMigrateDevelopment), autoMigrateDevelopment.ToString());
+        context.AddToConfiguration(section, nameof(DrnDevelopmentSettings.AutoMigrateStaging), autoMigrateStaging.ToString());
+    }
+
+    [Theory]
+    [DataInlineUnit(AppEnvironment.Development, true, false, true)]
+    [DataInlineUnit(AppEnvironment.Development, false, true, false)]
+    [DataInlineUnit(AppEnvironment.Staging, true, false, false)]
+    [DataInlineUnit(AppEnvironment.Staging, false, true, true)]
+    [DataInlineUnit(AppEnvironment.Production, true, true, false)]
+    public void Migrate_Flag_Should_Reflect_Environment_And_AutoMigrate_Settings(DrnTestContextUnit context,
+        AppEnvironment environment, bool autoMigrateDevelopment, bool autoMigrateStaging, bool migrationEnabled)
+    {
+        ConfigureEnvironment(context, environment, autoMigrateDevelopment, autoMigrateStaging);
+
+        var status = context.GetRequiredService<DevelopmentStatus>();
+        var model = CreateChangeModel();
+        status.AddChangeModel(model);
+
+        model.Flags.Migrate.Should().Be(migrationEnabled);
+    }
+}

--- a/Docker/Postgre/docker-compose.yml
+++ b/Docker/Postgre/docker-compose.yml
@@ -2,7 +2,7 @@ name: drn-postgres
 services:
   # https://hub.docker.com/_/postgres
   postgres:
-    image: postgres:18.2-alpine3.23
+    image: postgres:18.3-alpine3.23
     container_name: drn-postgres
     restart: unless-stopped
     volumes:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - drn-rabbit-etc:/etc/rabbitmq/
   # https://hub.docker.com/_/postgres
   postgres:
-    image: postgres:18.1-alpine3.23
+    image: postgres:18.3-alpine3.23
     container_name: drn-infra-postgres
     restart: unless-stopped
     volumes:

--- a/Sample.Hosted/Pages/Shared/_LayoutBase.cshtml
+++ b/Sample.Hosted/Pages/Shared/_LayoutBase.cshtml
@@ -36,7 +36,7 @@ They automatically resolve the correct script and stylesheet paths for both deve
     <script src="buildwww/app/js/appPreload.js" crossorigin="anonymous"></script>
     <script>
         DRN.App.Environment =  @Json.Serialize(ScopeContext.Settings.Environment.ToString());
-        DRN.App.IsDev = @Json.Serialize(ScopeContext.Settings.IsDevEnvironment);
+        DRN.App.IsDev = @Json.Serialize(ScopeContext.Settings.IsDevelopmentEnvironment);
         DRN.App.CsrfToken = @Json.Serialize(Context.GetCsrfToken());
         DRN.App.DefaultCulture = @Json.Serialize(ScopeContext.Settings.Localization.DefaultCulture);
         DRN.App.SupportedCultures = @Json.Serialize(ScopeContext.Settings.Localization.SupportedCultures);

--- a/Sample.Hosted/Pages/Shared/_SidebarActionbarBadges.cshtml
+++ b/Sample.Hosted/Pages/Shared/_SidebarActionbarBadges.cshtml
@@ -49,7 +49,7 @@
         </li>
     }
 
-    @if (ScopeContext.Settings.DevelopmentSettings.AutoMigrateDevelopment || ScopeContext.Settings.DevelopmentSettings.AutoMigrateStaging)
+    @if (ScopeContext.Settings.DevelopmentSettings.AutoMigrateDevelopment)
     {
         <li class="nav-item">
             <div title="Auto Migration Enabled" data-bs-toggle="tooltip" data-bs-placement="left">

--- a/Sample.Hosted/Pages/Shared/_SidebarActionbarBadges.cshtml
+++ b/Sample.Hosted/Pages/Shared/_SidebarActionbarBadges.cshtml
@@ -49,7 +49,7 @@
         </li>
     }
 
-    @if (ScopeContext.Settings.DevelopmentSettings.AutoMigrate)
+    @if (ScopeContext.Settings.DevelopmentSettings.AutoMigrateDevelopment || ScopeContext.Settings.DevelopmentSettings.AutoMigrateStaging)
     {
         <li class="nav-item">
             <div title="Auto Migration Enabled" data-bs-toggle="tooltip" data-bs-placement="left">

--- a/Sample.Hosted/SampleModule.cs
+++ b/Sample.Hosted/SampleModule.cs
@@ -22,7 +22,7 @@ public static class SampleModule
             .AddSampleApplicationServices()
             .Configure<FormOptions>(options => options.MultipartBodyLengthLimit = 1000 * 1024) // size limit
             .ConfigureCookieAuthenticationOptions(settings)
-            .AddIdentityApiEndpoints<SampleUser>(ConfigureIdentity(settings.IsDevEnvironment));
+            .AddIdentityApiEndpoints<SampleUser>(ConfigureIdentity(settings.IsDevelopmentEnvironment));
 
         //https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview
         //https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/

--- a/Sample.Hosted/appsettings.Development.json
+++ b/Sample.Hosted/appsettings.Development.json
@@ -8,7 +8,6 @@
   },
   "DrnDevelopmentSettings": {
     "Prototype": false,
-    "AutoMigrate": true,
     "LaunchExternalDependencies": true,
     "BreakForUserUnhandledException": false
   }


### PR DESCRIPTION
efactor(Utils): rename IsDevEnvironment and split AutoMigrate per environment

rename IsDevEnvironment to IsDevelopmentEnvironment
add IsStagingEnvironment property
split AutoMigrate into AutoMigrateDevelopment (default true)
and AutoMigrateStaging (default false)
update all consumers across Hosting, EntityFramework, Testing,
Nexus, Sample, and corresponding docs, tests, and skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-specific auto-migration controls for Development and Staging; explicit staging environment flag

* **Documentation**
  * New guidance on consolidating parameterized tests and data-driven testing; added lessons-learned and README/release-note updates

* **Refactor**
  * Renamed environment flags for clearer development/staging checks

* **Chores**
  * Updated Postgres image and test SDK version; added RabbitMQ volume in compose files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->