### PR TITLE
fix(Hosting): specify exact targets file path in PackagePath

### DIFF
--- a/AGENTS.LessonsLearned.md
+++ b/AGENTS.LessonsLearned.md
@@ -287,3 +287,21 @@ Explicitly enabled `knowledge_base.code_guidelines` in `.coderabbit.yaml` and se
 ### Decision Checkpoint
 
 Instead of bloating path instructions with generic text, use `reviews.path_instructions` only for path-specific overrides (like framework vs sample layers). Feed global project guidelines (like `AGENTS.md`) directly via `knowledge_base.code_guidelines.filePatterns`.
+
+## 13. NuGet buildTransitive Targets Need Exact Package Paths
+
+### Context
+
+`DRN.Framework.Hosting` ships a custom `buildTransitive` target so consuming web SDK projects include Vite manifests during publish.
+
+### Problem
+
+Using a folder-only `PackagePath` such as `buildTransitive/` can combine with item metadata like `RecursiveDir=buildTransitive/`, placing the file under a nested package path. NuGet then sees a `.targets` file somewhere under `buildTransitive/` but not the convention file `buildTransitive/{PackageId}.targets`, raising `NU5129` when warnings are treated as errors.
+
+### Fix Applied
+
+Set the package metadata to the full target file path, `buildTransitive/$(PackageId).targets`, and guard it with a unit test that reads the project file.
+
+### Decision Checkpoint
+
+For package `build`, `buildMultiTargeting`, and `buildTransitive` `.props` / `.targets` files, use the exact convention package path instead of relying on folder-only `PackagePath` behavior.

--- a/DRN.Framework.Hosting/DRN.Framework.Hosting.csproj
+++ b/DRN.Framework.Hosting/DRN.Framework.Hosting.csproj
@@ -37,7 +37,8 @@
         </None>
         <None Update="buildTransitive/DRN.Framework.Hosting.targets">
             <Pack>True</Pack>
-            <PackagePath>buildTransitive/</PackagePath>
+            <!-- NuGet expects buildTransitive/{PackageId}.targets exactly; folder-only paths can preserve RecursiveDir. -->
+            <PackagePath>buildTransitive/$(PackageId).targets</PackagePath>
         </None>
         <None Include="wwwroot\jsoneditor\Notes" />
     </ItemGroup>

--- a/DRN.Test.Unit/Tests/Framework/Hosting/ViteManifestPublishTargetsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/ViteManifestPublishTargetsTests.cs
@@ -6,6 +6,24 @@ public class ViteManifestPublishTargetsTests
 {
     [Theory]
     [DataInlineUnit]
+    public void HostingProject_Should_Pack_Targets_File_At_NuGet_Expected_BuildTransitive_Path(
+        DrnTestContextUnit context)
+    {
+        _ = context;
+        var document = XDocument.Load(FindHostingProjectFile());
+
+        var projectPackageId = document.Descendants("PackageId").Single().Value;
+        var packagedTargets = document.Descendants("None")
+            .Single(element => element.Attribute("Update")?.Value == "buildTransitive/DRN.Framework.Hosting.targets");
+
+        var evaluatedPackagePath = packagedTargets.Element("PackagePath")?.Value.Replace("$(PackageId)", projectPackageId);
+
+        packagedTargets.Element("Pack")?.Value.Should().Be("True");
+        evaluatedPackagePath.Should().Be($"buildTransitive/{projectPackageId}.targets");
+    }
+
+    [Theory]
+    [DataInlineUnit]
     public void HostingTargets_Should_Define_Vite_Manifest_Publish_Items_For_Web_Sdk_Projects(DrnTestContextUnit context)
     {
         _ = context;
@@ -34,24 +52,26 @@ public class ViteManifestPublishTargetsTests
         content.Attribute("CopyToPublishDirectory")?.Value.Should().Be("PreserveNewest");
     }
 
+    private static string FindHostingProjectFile()
+        => FindHostingFile("DRN.Framework.Hosting.csproj");
+
     private static string FindHostingTargetsFile()
+        => FindHostingFile("buildTransitive", "DRN.Framework.Hosting.targets");
+
+    private static string FindHostingFile(params string[] pathSegments)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
 
         while (directory != null)
         {
-            var targetsFile = Path.Combine(
-                directory.FullName,
-                "DRN.Framework.Hosting",
-                "buildTransitive",
-                "DRN.Framework.Hosting.targets");
+            var path = Path.Combine([directory.FullName, "DRN.Framework.Hosting", .. pathSegments]);
 
-            if (File.Exists(targetsFile))
-                return targetsFile;
+            if (File.Exists(path))
+                return path;
 
             directory = directory.Parent;
         }
 
-        throw new FileNotFoundException("Could not find DRN.Framework.Hosting.targets from the test output directory.");
+        throw new FileNotFoundException($"Could not find {Path.Combine(pathSegments)} from the test output directory.");
     }
 }


### PR DESCRIPTION
NuGet expects buildTransitive/{PackageId}.targets exactly. Folder-only package paths can combine with item metadata to preserve RecursiveDir, placing the file under a nested path and causing NU5129.

Also add a unit test to verify the targets file packaging path and refactor path helpers in ViteManifestPublishTargetsTests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NuGet package structure for build targets to align with standard conventions, ensuring proper file placement during package installation.

* **Tests**
  * Added unit test to verify correct package path configuration.

* **Documentation**
  * Added technical notes documenting the NuGet packaging issue and solution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->