### PR TITLE
feat(Utils): support stream hashing in HashExtensions

### DIFF
--- a/.agent/skills/drn-utils/SKILL.md
+++ b/.agent/skills/drn-utils/SKILL.md
@@ -217,7 +217,7 @@ if (scope.Acquired) { /* critical section */ }
 | Area | Key Types | Purpose |
 |------|-----------|---------|
 | **Data Encoding** | `EncodingExtensions` | Base64, Base64Url, Hex, Utf8 |
-| **Hashing** | `HashExtensions` | Blake3 (crypto), XxHash3 (fast), keyed hashing |
+| **Hashing** | `HashExtensions` | Blake3 (crypto), XxHash3 (fast), keyed and stream/file hashing |
 | **JSON** | `JsonMergePatch` | RFC 7386 merge patch with depth protection |
 | **Query Strings** | `QueryParameterSerializer` | Complex objects → query strings |
 | **Streams** | `ToBinaryDataAsync` | Safe consumption with `MaxSizeGuard` |

--- a/AGENTS.LessonsLearned.md
+++ b/AGENTS.LessonsLearned.md
@@ -288,7 +288,25 @@ Explicitly enabled `knowledge_base.code_guidelines` in `.coderabbit.yaml` and se
 
 Instead of bloating path instructions with generic text, use `reviews.path_instructions` only for path-specific overrides (like framework vs sample layers). Feed global project guidelines (like `AGENTS.md`) directly via `knowledge_base.code_guidelines.filePatterns`.
 
-## 13. NuGet buildTransitive Targets Need Exact Package Paths
+## 13. File Hashing Should Stream Large Inputs
+
+### Context
+
+`HashExtensions.HashOfFile` and `HashOfFileWithKey` originally loaded the entire file with `File.ReadAllBytes` before hashing.
+
+### Problem
+
+Whole-file reads create avoidable large allocations and duplicate memory pressure for file and payload hashing. This is especially costly for asset manifests, uploads, and other hot paths where the hash algorithm can already process incremental chunks.
+
+### Fix Applied
+
+Add `Stream` overloads for `Hash`, `HashToBinary`, `Hash64Bit`, and `HashWithKey`, then route file hashing through `File.OpenRead`. BLAKE3 stream hashing uses a pooled 16 KiB chunk buffer aligned with BLAKE3's SIMD guidance and clears it before returning it to the pool. The string-returning `Hash(Stream, ...)` overload encodes directly instead of routing through `BinaryData`.
+
+### Decision Checkpoint
+
+For files and large payloads, prefer stream overloads over `BinaryData` or byte arrays. Keep byte-array and `BinaryData` overloads for already-materialized data.
+
+## 14. NuGet buildTransitive Targets Need Exact Package Paths
 
 ### Context
 

--- a/DRN.Framework.Utils/Data/Hashing/HashExtensions.cs
+++ b/DRN.Framework.Utils/Data/Hashing/HashExtensions.cs
@@ -17,22 +17,38 @@ public static class HashExtensions
         HashAlgorithmSecure algorithm = HashAlgorithmSecure.Blake3With32CharKey,
         ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
     {
-        if (!File.Exists(filePath))
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            return stream.HashWithKey(key, algorithm, encoding);
+        }
+        catch (FileNotFoundException)
+        {
             return string.Empty;
-
-        using var stream = File.OpenRead(filePath);
-        return stream.HashWithKey(key, algorithm, encoding);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return string.Empty;
+        }
     }
 
     public static string HashOfFile(this string filePath,
         HashAlgorithm algorithm = HashAlgorithm.Blake3,
         ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
     {
-        if (!File.Exists(filePath))
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            return stream.Hash(algorithm, encoding);
+        }
+        catch (FileNotFoundException)
+        {
             return string.Empty;
-
-        using var stream = File.OpenRead(filePath);
-        return stream.Hash(algorithm, encoding);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return string.Empty;
+        }
     }
 
     public static string Hash(this string value,

--- a/DRN.Framework.Utils/Data/Hashing/HashExtensions.cs
+++ b/DRN.Framework.Utils/Data/Hashing/HashExtensions.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.IO.Hashing;
 using System.Security.Cryptography;
 using Blake3;
@@ -7,19 +8,32 @@ namespace DRN.Framework.Utils.Data.Hashing;
 
 public static class HashExtensions
 {
+    /// <summary>
+    /// Default buffer size for streaming data into BLAKE3; 16 KiB is large enough to leverage BLAKE3's currently supported SIMD paths.
+    /// </summary>
+    private const int Blake3StreamBufferSize = 16 * 1024;
+
     public static string HashOfFileWithKey(this string filePath, BinaryData key,
         HashAlgorithmSecure algorithm = HashAlgorithmSecure.Blake3With32CharKey,
-        ByteEncoding encoding = ByteEncoding.Base64UrlEncoded) =>
-        File.Exists(filePath)
-            ? new BinaryData(File.ReadAllBytes(filePath)).HashWithKey(key, algorithm, encoding)
-            : string.Empty;
+        ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
+    {
+        if (!File.Exists(filePath))
+            return string.Empty;
+
+        using var stream = File.OpenRead(filePath);
+        return stream.HashWithKey(key, algorithm, encoding);
+    }
 
     public static string HashOfFile(this string filePath,
         HashAlgorithm algorithm = HashAlgorithm.Blake3,
-        ByteEncoding encoding = ByteEncoding.Base64UrlEncoded) =>
-        File.Exists(filePath)
-            ? new BinaryData(File.ReadAllBytes(filePath)).Hash(algorithm, encoding)
-            : string.Empty;
+        ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
+    {
+        if (!File.Exists(filePath))
+            return string.Empty;
+
+        using var stream = File.OpenRead(filePath);
+        return stream.Hash(algorithm, encoding);
+    }
 
     public static string Hash(this string value,
         HashAlgorithm algorithm = HashAlgorithm.Blake3,
@@ -35,6 +49,22 @@ public static class HashExtensions
         HashAlgorithm algorithm = HashAlgorithm.Blake3,
         ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
         => new BinaryData(value).Hash(algorithm, encoding);
+
+    public static string Hash(this Stream stream,
+        HashAlgorithm algorithm = HashAlgorithm.Blake3,
+        ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        return algorithm switch
+        {
+            HashAlgorithm.Blake3 => GetBlake3Hash(stream).AsSpan().Encode(encoding),
+            HashAlgorithm.XxHash3_64 => GetXxHash3Hash(stream, encoding),
+            HashAlgorithm.Sha256 => GetSha256Hash(stream, encoding),
+            HashAlgorithm.Sha512 => GetSha512Hash(stream, encoding),
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+        };
+    }
 
     public static string Hash(this BinaryData bytes,
         HashAlgorithm algorithm = HashAlgorithm.Blake3,
@@ -62,6 +92,23 @@ public static class HashExtensions
     public static BinaryData HashToBinary(this ReadOnlyMemory<byte> value, HashAlgorithm algorithm = HashAlgorithm.Blake3)
         => new BinaryData(value).HashToBinary(algorithm);
 
+    public static BinaryData HashToBinary(this Stream stream, HashAlgorithm algorithm = HashAlgorithm.Blake3)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var hashBytes = algorithm switch
+        {
+            HashAlgorithm.Blake3 => GetBlake3Hash(stream).AsSpan().ToArray(),
+            HashAlgorithm.XxHash3_64 => GetXxHash3Hash(stream),
+            HashAlgorithm.Sha256 => SHA256.HashData(stream),
+            HashAlgorithm.Sha512 => SHA512.HashData(stream),
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+        };
+
+        var hash = BinaryData.FromBytes(hashBytes);
+        return hash;
+    }
+
     public static BinaryData HashToBinary(this BinaryData bytes, HashAlgorithm algorithm = HashAlgorithm.Blake3)
     {
         var hashBytes = algorithm switch
@@ -76,11 +123,12 @@ public static class HashExtensions
         var hash = BinaryData.FromBytes(hashBytes);
         return hash;
     }
-    
+
     public static ulong Hash64Bit(this byte[] value, long seed = 0) => XxHash3.HashToUInt64(value, seed);
     public static ulong Hash64Bit(this Span<byte> value, long seed = 0) => XxHash3.HashToUInt64(value, seed);
     public static ulong Hash64Bit(this ReadOnlySpan<byte> value, long seed = 0) => XxHash3.HashToUInt64(value, seed);
     public static ulong Hash64Bit(this ReadOnlyMemory<byte> value, long seed = 0) => new BinaryData(value).Hash64Bit(seed);
+    public static ulong Hash64Bit(this Stream value, long seed = 0) => GetXxHash3Hash64Bit(value, seed);
     public static ulong Hash64Bit(this string value, long seed = 0) => BinaryData.FromString(value).Hash64Bit(seed);
     public static ulong Hash64Bit(this BinaryData value, long seed = 0) => XxHash3.HashToUInt64(value, seed);
 
@@ -99,6 +147,23 @@ public static class HashExtensions
         ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
         => new BinaryData(value).HashWithKey(key, algorithm, encoding);
 
+    public static string HashWithKey(this Stream stream, BinaryData key,
+        HashAlgorithmSecure algorithm = HashAlgorithmSecure.Blake3With32CharKey,
+        ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var hashBytes = algorithm switch
+        {
+            HashAlgorithmSecure.Blake3With32CharKey => GetBlake3HashWithKey(stream, key).AsSpan(),
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+        };
+
+        var hash = hashBytes.Encode(encoding);
+
+        return hash;
+    }
+
     public static string HashWithKey(this BinaryData bytes, BinaryData key,
         HashAlgorithmSecure algorithm = HashAlgorithmSecure.Blake3With32CharKey,
         ByteEncoding encoding = ByteEncoding.Base64UrlEncoded)
@@ -114,12 +179,106 @@ public static class HashExtensions
         return hash;
     }
 
+    private static Hash GetBlake3Hash(Stream stream)
+    {
+        // Hasher is a mutable struct passed by ref to UpdateBlake3Hasher.
+        // A 'using' variable is read-only and cannot be passed as a ref parameter.
+        // Hence, we must use a manual try/finally block to ensure proper disposal.
+        var hasher = Hasher.New();
+
+        try
+        {
+            UpdateBlake3Hasher(stream, ref hasher);
+            return hasher.Finalize();
+        }
+        finally
+        {
+            hasher.Dispose();
+        }
+    }
+
     private static Hash GetBlake3HashWithKey(BinaryData bytes, BinaryData key)
     {
         using var hasher = Hasher.NewKeyed(key);
         hasher.Update(bytes);
 
         return hasher.Finalize();
+    }
+
+    private static Hash GetBlake3HashWithKey(Stream stream, BinaryData key)
+    {
+        // Hasher is a mutable struct passed by ref to UpdateBlake3Hasher.
+        // A 'using' variable is read-only and cannot be passed as a ref parameter.
+        // Hence, we must use a manual try/finally block to ensure proper disposal.
+        var hasher = Hasher.NewKeyed(key);
+
+        try
+        {
+            UpdateBlake3Hasher(stream, ref hasher);
+            return hasher.Finalize();
+        }
+        finally
+        {
+            hasher.Dispose();
+        }
+    }
+
+    private static void UpdateBlake3Hasher(Stream stream, ref Hasher hasher)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(Blake3StreamBufferSize);
+
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0)
+                hasher.Update(buffer.AsSpan(0, bytesRead));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+        }
+    }
+
+    private static byte[] GetXxHash3Hash(Stream stream)
+    {
+        var hasher = new XxHash3(0);
+        hasher.Append(stream);
+
+        return hasher.GetCurrentHash();
+    }
+
+    private static string GetXxHash3Hash(Stream stream, ByteEncoding encoding)
+    {
+        Span<byte> hashBytes = stackalloc byte[sizeof(ulong)];
+        var hasher = new XxHash3(0);
+        hasher.Append(stream);
+        hasher.GetCurrentHash(hashBytes);
+
+        return hashBytes.Encode(encoding);
+    }
+
+    private static ulong GetXxHash3Hash64Bit(Stream stream, long seed)
+    {
+        var hasher = new XxHash3(seed);
+        hasher.Append(stream);
+
+        return hasher.GetCurrentHashAsUInt64();
+    }
+
+    private static string GetSha256Hash(Stream stream, ByteEncoding encoding)
+    {
+        Span<byte> hashBytes = stackalloc byte[SHA256.HashSizeInBytes];
+        SHA256.HashData(stream, hashBytes);
+
+        return hashBytes.Encode(encoding);
+    }
+
+    private static string GetSha512Hash(Stream stream, ByteEncoding encoding)
+    {
+        Span<byte> hashBytes = stackalloc byte[SHA512.HashSizeInBytes];
+        SHA512.HashData(stream, hashBytes);
+
+        return hashBytes.Encode(encoding);
     }
 
     public static long GenerateSeedFromInputHash(this string input, byte hashStartIndex = 19)

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -471,6 +471,7 @@ High-performance hashing extensions supporting modern and legacy algorithms.
 *   **Blake3**: Default modern cryptographic hash (fast and secure).
 *   **XxHash3**: Non-cryptographic hashing for performance-critical scenarios (IDs, Cache keys).
 *   **Security**: Keyed hashing support (`HashWithKey`) for integrity protection.
+*   **Streams**: Stream overloads hash files and large payloads without first materializing them as `BinaryData`.
 
 ### JSON & Document Utilities
 *   **JSON Merge Patch**: `JsonMergePatch.SafeApplyMergePatch` follows RFC 7386 for partial updates with built-in recursion depth protection.
@@ -523,6 +524,7 @@ var query = model.Serialize(SerializationMethod.QueryString);
 
 // Data Integrity
 var hash = data.Hash(HashAlgorithm.Blake3);
+var fileHash = fileStream.Hash(HashAlgorithm.Sha256);
 
 // Secure stream conversion
 var bytes = await requestStream.ToBinaryDataAsync(maxSize: 1024 * 1024);

--- a/DRN.Framework.Utils/RELEASE-NOTES.md
+++ b/DRN.Framework.Utils/RELEASE-NOTES.md
@@ -6,6 +6,7 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 *   **Rate Limiting Settings**: Added validated `DrnAppFeatures:DrnRateLimit` knobs for DRN Hosting rate limiting (`Disabled`, partition log mode, shared token limit, replenishment period, tokens per period, B2B-friendly pre-auth defaults, and optional pre-auth/post-auth overrides), exposed in code as `IAppSettings.Features.RateLimit`.
 *   **Test Scope Initialization**: `ScopeContext.InitializeForTest(...)` is now public and resets the current async-local scope before initialization, preventing stale test scope data from leaking between helper calls.
+*   **Stream Hashing Support**: Added stream and file hashing overloads in `HashExtensions` (supporting Blake3, XxHash3, Sha256, Sha512, and keyed Blake3/XxHash3 algorithms) to hash files and large payloads without first materializing them as `BinaryData`.
 
 ## Version 0.9.4
 

--- a/DRN.Test.Unit/Tests/Framework/Utils/Encodings/HashExtensionTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Encodings/HashExtensionTests.cs
@@ -30,6 +30,8 @@ public class HashExtensionTests
         new BinaryData(HelloWorld).Hash(algorithm, ByteEncoding.Hex).Should().Be(expectedHashHex);
         new BinaryData(HelloWorld).ToArray().Hash(algorithm, ByteEncoding.Hex).Should().Be(expectedHashHex);
         new BinaryData(HelloWorld).ToMemory().Hash(algorithm, ByteEncoding.Hex).Should().Be(expectedHashHex);
+        using var stream = new MemoryStream(new BinaryData(HelloWorld).ToArray());
+        stream.Hash(algorithm, ByteEncoding.Hex).Should().Be(expectedHashHex);
 
         var expectedBase64Hash = hashHex.Decode(ByteEncoding.Hex).Encode(ByteEncoding.Base64);
         var base64Hash = HelloWorld.Hash(algorithm, ByteEncoding.Base64);
@@ -51,6 +53,8 @@ public class HashExtensionTests
         new BinaryData(HelloWorld).HashToBinary().ToArray().Encode(ByteEncoding.Hex).Should().Be(HelloWorldBlake3Hash);
         new BinaryData(HelloWorld).ToArray().HashToBinary().ToArray().Encode(ByteEncoding.Hex).Should().Be(HelloWorldBlake3Hash);
         new BinaryData(HelloWorld).ToMemory().HashToBinary().ToArray().Encode(ByteEncoding.Hex).Should().Be(HelloWorldBlake3Hash);
+        using var stream = new MemoryStream(new BinaryData(HelloWorld).ToArray());
+        stream.HashToBinary().ToArray().Encode(ByteEncoding.Hex).Should().Be(HelloWorldBlake3Hash);
     }
 
     [Fact]
@@ -67,6 +71,8 @@ public class HashExtensionTests
         new BinaryData(HelloWorld).ToMemory().Hash64Bit().Should().Be(expectedHash64Bit);
         new BinaryData(HelloWorld).ToMemory().Span.Hash64Bit().Should().Be(expectedHash64Bit);
         new BinaryData(HelloWorld).ToArray().AsSpan().Hash64Bit().Should().Be(expectedHash64Bit);
+        using var stream = new MemoryStream(new BinaryData(HelloWorld).ToArray());
+        stream.Hash64Bit().Should().Be(expectedHash64Bit);
     }
 
     [Fact]
@@ -86,6 +92,10 @@ public class HashExtensionTests
         hashHex = helloWorldBinary.ToMemory().HashWithKey(helloWorldKeyBinary, HashAlgorithmSecure.Blake3With32CharKey, ByteEncoding.Hex);
         hashHex.Should().Be(HelloWorldBlake3HashWithKey);
 
+        using var stream = new MemoryStream(helloWorldBinary.ToArray());
+        hashHex = stream.HashWithKey(helloWorldKeyBinary, HashAlgorithmSecure.Blake3With32CharKey, ByteEncoding.Hex);
+        hashHex.Should().Be(HelloWorldBlake3HashWithKey);
+
         HelloWorld.GenerateSeedFromInputHash().Should().Be(4938522919252271305);
     }
 
@@ -98,5 +108,11 @@ public class HashExtensionTests
 
         path.HashOfFile(encoding: ByteEncoding.Hex).Should().Be(HelloWorldBlake3Hash);
         path.HashOfFileWithKey(new BinaryData(HelloWorldKey), encoding: ByteEncoding.Hex).Should().Be(HelloWorldBlake3HashWithKey);
+
+        using var stream = File.OpenRead(path);
+        stream.Hash(encoding: ByteEncoding.Hex).Should().Be(HelloWorldBlake3Hash);
+
+        using var keyedStream = File.OpenRead(path);
+        keyedStream.HashWithKey(new BinaryData(HelloWorldKey), encoding: ByteEncoding.Hex).Should().Be(HelloWorldBlake3HashWithKey);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream-based hashing for large files/payloads without full in-memory materialization; supports BLAKE3 (including keyed), xxHash3 (64-bit), SHA-256, and SHA-512.

* **Documentation**
  * Updated docs and release notes with stream-hashing guidance and examples; added best-practice guidance for file hashing.

* **Tests**
  * Expanded tests to validate stream-based hashing and keyed hashing across algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->