### PR TITLE
chore(ci): prepend release tag triggers with release/ prefix

### DIFF
--- a/.github/workflows/actions/docker-publish/action.yml
+++ b/.github/workflows/actions/docker-publish/action.yml
@@ -15,8 +15,8 @@ runs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{version}},match=^release/v(\d+\.\d+\.\d+(?:-preview[0-9]*)?)$
+          type=semver,pattern={{major}}.{{minor}},match=^release/v(\d+\.\d+\.\d+(?:-preview[0-9]*)?)$
     - name: Build and push Docker image
       id: container-build-push
       uses: docker/build-push-action@v6

--- a/.github/workflows/actions/docker-publish/action.yml
+++ b/.github/workflows/actions/docker-publish/action.yml
@@ -11,12 +11,12 @@ runs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-          images: duranserkan/${{ inputs.image-repository-name }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+        images: duranserkan/${{ inputs.image-repository-name }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
     - name: Build and push Docker image
       id: container-build-push
       uses: docker/build-push-action@v6
@@ -37,6 +37,8 @@ runs:
         command: quickview,cves,recommendations
         sarif-file: sarif.${{ inputs.project-name }}.output.json
         summary: true
+        only-severities: critical,high,medium
+        ignore-base: true
     - name: Upload SARIF result
       id: upload-container-sarif
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/actions/sonar-begin/action.yml
+++ b/.github/workflows/actions/sonar-begin/action.yml
@@ -7,4 +7,4 @@ runs:
     - name: Sonar Scan Begin # Sonar Begin
       shell: pwsh
       run: |
-        ./.sonar/scanner/dotnet-sonarscanner begin /k:"$env:SONAR_PROJECT_KEY" /o:"$env:SONAR_ORGANIZATION" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.host.url="$env:SONAR_HOST_URL"
+        ./.sonar/scanner/dotnet-sonarscanner begin /k:"$env:SONAR_PROJECT_KEY" /o:"$env:SONAR_ORGANIZATION" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.cs.vscoveragexml.reportsPaths=coverage-unit.xml,coverage-integration.xml /d:sonar.host.url="$env:SONAR_HOST_URL"

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     permissions:
-      security-events: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   build-and-sonar-scan:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -35,10 +37,10 @@ jobs:
         uses: ./.github/workflows/actions/dotnet-build
 
       - name: Test Unit
-        run: ./.sonar/coverage/dotnet-coverage collect "dotnet run --project DRN.Test.Unit/DRN.Test.Unit.csproj --no-build --verbosity normal" -f xml -o "coverage.xml"
+        run: ./.sonar/coverage/dotnet-coverage collect "dotnet run --project DRN.Test.Unit/DRN.Test.Unit.csproj --no-build --verbosity normal" -f xml -o "coverage-unit.xml"
 
       - name: Test Integration
-        run: ./.sonar/coverage/dotnet-coverage collect "dotnet run --project DRN.Test.Integration/DRN.Test.Integration.csproj --no-build --verbosity normal" -f xml -o "coverage.xml"
+        run: ./.sonar/coverage/dotnet-coverage collect "dotnet run --project DRN.Test.Integration/DRN.Test.Integration.csproj --no-build --verbosity normal" -f xml -o "coverage-integration.xml"
 
       - name: Sonar Scan End
         uses: ./.github/workflows/actions/sonar-end

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -5,6 +5,11 @@ on:
   push:
     tags:
       - release/v[0-9]+.[0-9]+.[0-9]+-preview[0-9][0-9][0-9]
+
+concurrency:
+  group: release-preview-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   Publish-Develop:
     permissions:

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -4,7 +4,7 @@ name: release-preview
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+-preview[0-9][0-9][0-9]
+      - release/v[0-9]+.[0-9]+.[0-9]+-preview[0-9][0-9][0-9]
 jobs:
   Publish-Develop:
     permissions:
@@ -27,7 +27,7 @@ jobs:
         run: git branch --remote --contains | grep origin/develop
 
       - name: Set VERSION variable from tag
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/release\/v/}" >> $GITHUB_ENV
 
       - name: Setup SDK
         uses: ./.github/workflows/actions/setup-sdk-and-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
   push:
     tags:
       - release/v[0-9]+.[0-9]+.[0-9]+
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   Publish-Master:
     permissions:
@@ -61,3 +66,6 @@ jobs:
 
       - name: Publish Images
         uses: ./.github/workflows/actions/docker-publish-all
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - release/v[0-9]+.[0-9]+.[0-9]+
 jobs:
   Publish-Master:
     permissions:
@@ -27,7 +27,7 @@ jobs:
         run: git branch --remote --contains | grep origin/master
 
       - name: Set VERSION variable from tag
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/release\/v/}" >> $GITHUB_ENV
 
       - name: Setup SDK
         uses: ./.github/workflows/actions/setup-sdk-and-tools

--- a/AGENTS.LessonsLearned.md
+++ b/AGENTS.LessonsLearned.md
@@ -323,3 +323,21 @@ Set the package metadata to the full target file path, `buildTransitive/$(Packag
 ### Decision Checkpoint
 
 For package `build`, `buildMultiTargeting`, and `buildTransitive` `.props` / `.targets` files, use the exact convention package path instead of relying on folder-only `PackagePath` behavior.
+
+## 15. Docker Scout Reads .NET Shared-Framework Metadata from deps.json
+
+### Context
+
+RID-specific, framework-dependent Docker publishes can emit `.deps.json` entries for shared frameworks such as `Microsoft.NETCore.App` and `Microsoft.AspNetCore.App`. Vulnerability scanners may treat those metadata entries as installed packages even when the final image supplies a patched shared runtime.
+
+### Problem
+
+For framework-dependent apps, `TargetLatestRuntimePatch` defaults to `false`. A Dockerfile can therefore run on a patched base image while generated `.deps.json` files still reference the target framework's default or previously restored runtime patch, producing Docker Scout false positives.
+
+### Fix Applied
+
+Keep the final ASP.NET runtime image patch and the restore/build/publish metadata aligned. Docker builds pin the runtime version once and pass `RuntimeFrameworkVersion`, `TargetLatestRuntimePatch=true`, `SelfContained=false`, and `UseAppHost=false` consistently through restore, build, and publish.
+
+### Decision Checkpoint
+
+When upgrading .NET Docker runtime patches, update the Docker runtime image tag and the publish metadata together. If a scanner still reports a non-applicable CVE after metadata is aligned, attach a Docker Scout exception or VEX statement rather than deleting required `.deps.json` files.

--- a/DRN.Nexus.Hosted/Dockerfile
+++ b/DRN.Nexus.Hosted/Dockerfile
@@ -3,11 +3,14 @@
 #https://www.jetbrains.com/help/rider/Docker_fast_mode.html
 #from solution root: docker build -f DRN.Nexus.Hosted/Dockerfile -t drn/nexus.hosted:localbuild .
 ARG PROJECT=DRN.Nexus.Hosted
+ARG DOTNET_RUNTIME_VERSION=10.0.8
+ARG DOTNET_SDK_VERSION=10.0.300
+ARG DOTNET_DISTRO=resolute
 
 #https://www.mytechramblings.com/posts/testing-chiseled-ubuntu-containers-with-dotnet/
 #https://hub.docker.com/r/ubuntu/dotnet-aspnet use this dotnet deps with self contained apps are not supported with dockerfastmode
 #https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/ enable buildkit to build multiplatform images
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8-resolute-chiseled-extra AS base
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_RUNTIME_VERSION}-${DOTNET_DISTRO}-chiseled-extra AS base
 ARG TARGETARCH
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -25,17 +28,31 @@ WORKDIR /app
 #https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build
 #https://mcr.microsoft.com/en-us/artifact/mar/dotnet/sdk/tags
 #build image should use same distro with base image to prevent mismatches such as Alpine (Musl) vs. Ubuntu (Glibc)
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.300-resolute   AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_VERSION}-${DOTNET_DISTRO} AS build
 ARG PROJECT
 ARG TARGETARCH
+ARG DOTNET_RUNTIME_VERSION
 
 WORKDIR /app
 COPY . ./
 
 #https://learn.microsoft.com/en-us/dotnet/core/rid-catalog
-RUN dotnet restore "./${PROJECT}/${PROJECT}.csproj"  -a "$TARGETARCH"
-RUN dotnet build "./${PROJECT}/${PROJECT}.csproj" -c Release  --no-restore -a "$TARGETARCH"
-RUN dotnet publish "./${PROJECT}/${PROJECT}.csproj" -c Release -o /app/publish --no-restore --no-build -a "$TARGETARCH"
+# Keep generated .deps.json framework metadata aligned with the runtime image patch level.
+RUN dotnet restore "./${PROJECT}/${PROJECT}.csproj" -a "$TARGETARCH" \
+    -p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION" \
+    -p:TargetLatestRuntimePatch=true \
+    -p:SelfContained=false \
+    -p:UseAppHost=false
+RUN dotnet build "./${PROJECT}/${PROJECT}.csproj" -c Release --no-restore -a "$TARGETARCH" \
+    -p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION" \
+    -p:TargetLatestRuntimePatch=true \
+    -p:SelfContained=false \
+    -p:UseAppHost=false
+RUN dotnet publish "./${PROJECT}/${PROJECT}.csproj" -c Release -o /app/publish --no-restore --no-build -a "$TARGETARCH" \
+    -p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION" \
+    -p:TargetLatestRuntimePatch=true \
+    -p:SelfContained=false \
+    -p:UseAppHost=false
 
 # Build runtime image
 FROM base AS final

--- a/Sample.Hosted/Dockerfile
+++ b/Sample.Hosted/Dockerfile
@@ -3,13 +3,16 @@
 #https://www.jetbrains.com/help/rider/Docker_fast_mode.html
 #from solution root: docker build -f Sample.Hosted/Dockerfile -t drn/sample.hosted:localbuild .
 ARG PROJECT=Sample.Hosted
+ARG DOTNET_RUNTIME_VERSION=10.0.8
+ARG DOTNET_SDK_VERSION=10.0.300
+ARG DOTNET_DISTRO=resolute
 
 #https://www.mytechramblings.com/posts/testing-chiseled-ubuntu-containers-with-dotnet/
 #https://hub.docker.com/r/ubuntu/dotnet-aspnet use this dotnet deps with self contained apps are not supported with dockerfastmode
 #https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/ enable buildkit to build multiplatform images
 #https://mcr.microsoft.com/en-us/artifact/mar/dotnet/aspnet/tags alternative registry for ubuntu/dotnet-aspnet
 #https://github.com/dotnet/dotnet-docker
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8-resolute-chiseled-extra AS base
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_RUNTIME_VERSION}-${DOTNET_DISTRO}-chiseled-extra AS base
 ARG TARGETARCH
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -27,17 +30,31 @@ WORKDIR /app
 #https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build
 #https://mcr.microsoft.com/en-us/artifact/mar/dotnet/sdk/tags
 #build image should use same distro with base image to prevent mismatches such as Alpine (Musl) vs. Ubuntu (Glibc)
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.300-resolute AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_VERSION}-${DOTNET_DISTRO} AS build
 ARG PROJECT
 ARG TARGETARCH
+ARG DOTNET_RUNTIME_VERSION
 
 WORKDIR /app
 COPY . ./
 
 #https://learn.microsoft.com/en-us/dotnet/core/rid-catalog
-RUN dotnet restore "./${PROJECT}/${PROJECT}.csproj"  -a "$TARGETARCH"
-RUN dotnet build "./${PROJECT}/${PROJECT}.csproj" -c Release  --no-restore -a "$TARGETARCH"
-RUN dotnet publish "./${PROJECT}/${PROJECT}.csproj" -c Release -o /app/publish --no-restore --no-build -a "$TARGETARCH"
+# Keep generated .deps.json framework metadata aligned with the runtime image patch level.
+RUN dotnet restore "./${PROJECT}/${PROJECT}.csproj" -a "$TARGETARCH" \
+    -p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION" \
+    -p:TargetLatestRuntimePatch=true \
+    -p:SelfContained=false \
+    -p:UseAppHost=false
+RUN dotnet build "./${PROJECT}/${PROJECT}.csproj" -c Release --no-restore -a "$TARGETARCH" \
+    -p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION" \
+    -p:TargetLatestRuntimePatch=true \
+    -p:SelfContained=false \
+    -p:UseAppHost=false
+RUN dotnet publish "./${PROJECT}/${PROJECT}.csproj" -c Release -o /app/publish --no-restore --no-build -a "$TARGETARCH" \
+    -p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION" \
+    -p:TargetLatestRuntimePatch=true \
+    -p:SelfContained=false \
+    -p:UseAppHost=false
 
 # Build runtime image
 FROM base AS final


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows with revised release tag naming convention.
  * Enhanced Docker Scout security scanning configuration with severity filtering and SARIF upload.
  * Improved Docker builds with parameterized .NET SDK and runtime versions for better multi-platform support.

* **Documentation**
  * Added guidance on resolving Docker Scout false positives related to framework metadata alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->