### PR TITLE
feat(Utils): support alternative Nexus MAC key encodings and key ring

### DIFF
--- a/.agent/skills/drn-utils/SKILL.md
+++ b/.agent/skills/drn-utils/SKILL.md
@@ -129,6 +129,21 @@ Override mount directory via `IMountedSettingsConventionsOverride`.
 
 When grouping options into nested objects, explicitly validate child objects before relying on child data annotations for startup safety; plain `Validator.TryValidateObject` does not recursively walk nested option objects.
 
+### Nexus MAC Keys
+
+`NexusAppSettings.MacKeys` must contain exactly one default `NexusMacKey`. Generation uses the default key; parsing tries the default key first and then the remaining configured keys for rotation fallback.
+
+`NexusMacKey.Format` defaults to `ByteEncoding.Utf8` and supports:
+
+| Format | Requirement |
+|--------|-------------|
+| `Utf8` | Key is exactly 32 UTF-8 bytes. |
+| `Hex` | Hex decodes to exactly 32 bytes, normally 64 hex chars. |
+| `Base64` | Base64 decodes to exactly 32 bytes. |
+| `Base64UrlEncoded` | Base64Url decodes to exactly 32 bytes. |
+
+Do not hash, pad, truncate, auto-detect, or repair configured keys. In `Development`, when no default MAC key is configured, `AppSettings` deterministically derives a Base64Url key from `DrnAppFeatures.SeedKey` through `AppSecuritySettings` and the default `Hash()` extension.
+
 ---
 
 ## Scoped Logging (IScopedLog)

--- a/.sample-env
+++ b/.sample-env
@@ -19,7 +19,11 @@ POSTGRES_PASSWORD=drn
 POSTGRES_DB=drn
 PGDATA=/data/postgres
 
+# Development without an explicit default MacKey derives one deterministically from DrnAppFeatures__SeedKey.
+# Changing SeedKey changes generated IDs unless the previous key remains in NexusAppSettings__MacKeys.
+# Alternative MacKey formats: set Format to Hex, Base64, or Base64UrlEncoded; decoded bytes must be exactly 32.
 NexusAppSettings__MacKeys__0__Key=1019464a0c19475693c155fcb0f7b3e8
+NexusAppSettings__MacKeys__0__Format=Utf8
 NexusAppSettings__MacKeys__0__Default=true
 
 NLog__targets__graylog-udp__address=udp://graylog:12201

--- a/.sample-env
+++ b/.sample-env
@@ -22,7 +22,7 @@ PGDATA=/data/postgres
 # Development without an explicit default MacKey derives one deterministically from DrnAppFeatures__SeedKey.
 # Changing SeedKey changes generated IDs unless the previous key remains in NexusAppSettings__MacKeys.
 # Alternative MacKey formats: set Format to Hex, Base64, or Base64UrlEncoded; decoded bytes must be exactly 32.
-NexusAppSettings__MacKeys__0__Key=1019464a0c19475693c155fcb0f7b3e8
+NexusAppSettings__MacKeys__0__Key=sample-mac-key-00000000000000000
 NexusAppSettings__MacKeys__0__Format=Utf8
 NexusAppSettings__MacKeys__0__Default=true
 

--- a/DRN.Framework.Utils/Data/Encodings/ByteEncoding.cs
+++ b/DRN.Framework.Utils/Data/Encodings/ByteEncoding.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace DRN.Framework.Utils.Data.Encodings;
 
+[JsonConverter(typeof(JsonStringEnumConverter<ByteEncoding>))]
 public enum ByteEncoding
 {
     Hex = 1,

--- a/DRN.Framework.Utils/Data/Encryption/NexusKeyMaterial.cs
+++ b/DRN.Framework.Utils/Data/Encryption/NexusKeyMaterial.cs
@@ -1,0 +1,33 @@
+using System.Security.Cryptography;
+using DRN.Framework.Utils.Settings;
+
+namespace DRN.Framework.Utils.Data.Encryption;
+
+internal sealed class NexusKeyMaterial(NexusMacKey macKey) : IDisposable
+{
+    // KeyAsBinary is used only for BLAKE3 keyed MAC integrity checks.
+    public BinaryData MacKey { get; } = macKey.KeyAsBinary;
+
+    // AlternativeKeyAsBinary is a derived, separate 32-byte key used only for AES-256 encryption.
+    // AES-256 retains 128-bit security under Grover's algorithm and is suitable for post-quantum symmetric strength.
+    public Aes Aes { get; } = CreateAes(macKey.AlternativeKeyAsBinary);
+
+    public void Dispose() => Aes.Dispose();
+
+    private static Aes CreateAes(BinaryData key)
+    {
+        var keyBytes = key.ToArray();
+        if (keyBytes.Length != 32)
+            throw new ArgumentException(
+                $"AES-256-ECB requires a 32-byte key but received {keyBytes.Length} bytes. " +
+                $"Verify that AlternativeKeyAsBinary produces a 256-bit key.",
+                nameof(key));
+
+        var aes = Aes.Create();
+        aes.Mode = CipherMode.ECB;
+        aes.Padding = PaddingMode.None;
+        aes.Key = keyBytes;
+
+        return aes;
+    }
+}

--- a/DRN.Framework.Utils/Data/Encryption/NexusKeyRing.cs
+++ b/DRN.Framework.Utils/Data/Encryption/NexusKeyRing.cs
@@ -1,0 +1,28 @@
+using DRN.Framework.Utils.Settings;
+
+namespace DRN.Framework.Utils.Data.Encryption;
+
+internal sealed class NexusKeyRing : IDisposable
+{
+    public NexusKeyRing(NexusAppSettings settings)
+    {
+        var defaultMacKey = settings.GetDefaultMacKey();
+        Default = new NexusKeyMaterial(defaultMacKey);
+        Fallback = settings.MacKeys
+            .Where(key => !key.Default)
+            .Select(key => new NexusKeyMaterial(key))
+            .ToArray();
+
+        AllWithDefaultAsFirstItem = [Default, ..Fallback];
+    }
+
+    public NexusKeyMaterial Default { get; }
+    public IReadOnlyList<NexusKeyMaterial> Fallback { get; }
+    public IReadOnlyList<NexusKeyMaterial> AllWithDefaultAsFirstItem { get; }
+
+    public void Dispose()
+    {
+        foreach (var key in AllWithDefaultAsFirstItem)
+            key.Dispose();
+    }
+}

--- a/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
+++ b/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
@@ -492,7 +492,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     /// </list>
     /// </para>
     /// <para>
-    /// Concurrency validated with stress tests generating ~800,000 IDs across 8 parallel threads without data races or corruption.
+    /// Concurrency validated with <c>SourceKnownEntityIdUtils_Should_Generate_Ids_For_3_Seconds</c> generating ~800,000 IDs across 8 parallel threads without data races or corruption.
     /// </para>
     /// For a single 128-bit block, ECB is mathematically identical to CBC with a zero IV
     /// (C = AES(Key, P ⊕ 0) = AES(Key, P)), but avoids the IV allocation and XOR overhead.

--- a/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
+++ b/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
@@ -478,8 +478,22 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
 
     /// <summary>
     /// Encrypts all 16 guid bytes in-place using AES-256-ECB (single-block PRP).
-    /// EncryptEcb/DecryptEcb are stateless single-block operations safe for concurrent use by this singleton service.
-    /// Stress covered by SourceKnownEntityIdUtilsTests.
+    /// <para>
+    /// <b>Thread-Safety Verification:</b>
+    /// Although the general MSDN documentation states "Any instance members of <see cref="Aes"/> are not guaranteed to be thread safe",
+    /// the span-based one-shot methods <c>EncryptEcb</c> and <c>DecryptEcb</c> are state-free and do not mutate or store any state on the Aes instance itself.
+    /// </para>
+    /// <para>
+    /// Platform-specific implementation details:
+    /// <list type="bullet">
+    /// <item><description><b>Windows (CNG):</b> Calls BCryptEncrypt using the native CNG key handle. Under CNG, key handles are thread-safe for concurrent stateless operations.</description></item>
+    /// <item><description><b>macOS (AppleCommonCrypto):</b> Calls CCCrypt, a pure C function that is completely stateless.</description></item>
+    /// <item><description><b>Linux (OpenSSL):</b> Allocates a temporary local context (SafeEvpCipherCtxHandle) inside the call, avoiding any shared state on the Aes instance.</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Concurrency validated with stress tests generating ~800,000 IDs across 8 parallel threads without data races or corruption.
+    /// </para>
     /// For a single 128-bit block, ECB is mathematically identical to CBC with a zero IV
     /// (C = AES(Key, P ⊕ 0) = AES(Key, P)), but avoids the IV allocation and XOR overhead.
     /// ECB's known weakness (identical blocks → identical ciphertexts) does not apply here
@@ -494,7 +508,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
 
     /// <summary>
     /// Decrypts all 16 guid bytes in-place using AES-256-ECB (single-block PRP inverse).
-    /// See <see cref="EncryptGuidBlock"/> for rationale on ECB vs CBC for single-block operations.
+    /// See <see cref="EncryptGuidBlock"/> for thread-safety details and rationale on ECB vs CBC for single-block operations.
     /// </summary>
     private static void DecryptGuidBlock(Span<byte> guidBytes, Aes aes)
     {

--- a/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
+++ b/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
@@ -2,6 +2,7 @@ using System.Buffers.Binary;
 using System.Security.Cryptography;
 using Blake3;
 using DRN.Framework.SharedKernel.Domain;
+using DRN.Framework.Utils.Data.Encryption;
 using DRN.Framework.Utils.DependencyInjection.Attributes;
 using DRN.Framework.Utils.Numbers;
 using DRN.Framework.Utils.Settings;
@@ -58,7 +59,7 @@ public interface ISourceKnownEntityIdUtils : ISourceKnownEntityIdOperations
 /// If still not enough, don't use source known ids, consider using a different id generation strategy such as true guid v4.
 /// </summary>
 [Singleton<ISourceKnownEntityIdUtils>]
-public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKnownIdUtils sourceKnownIdUtils) : ISourceKnownEntityIdUtils, IDisposable
+public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDisposable
 {
     // RFC 9562 V8 big-endian byte layout (network byte order):
     // 0    epoch
@@ -115,14 +116,21 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
     // Key separation: KeyAsBinary and AlternativeKeyAsBinary are cryptographically independent keys from the same keyring entry.
     // KeyAsBinary → BLAKE3 keyed MAC (integrity). AlternativeKeyAsBinary → AES-256-ECB (confidentiality).
-    private readonly BinaryData _defaultMacKey = appSettings.NexusAppSettings.GetDefaultMacKey().KeyAsBinary; // todo add keyring rotation
-    private readonly bool _useSecure = appSettings.NexusAppSettings.UseSecureSourceKnownIds;
+    private readonly NexusKeyRing _keyRing;
+    private readonly Aes _aes;
+    private readonly BinaryData _macKey;
+    private readonly bool _useSecure;
+    private readonly ISourceKnownIdUtils _sourceKnownIdUtils;
 
-    // Singleton — DI container disposes at shutdown.
-    // Stress tested with SourceKnownEntityIdUtilsTests
-    // EncryptEcb/DecryptEcb are stateless single-block ops safe for concurrent use.
-    // Post-quantum readiness: AES-256 retains 128-bit security under Grover's algorithm — NIST recommended for post-quantum symmetric encryption.
-    private readonly Aes _aes = CreateAes(appSettings.NexusAppSettings.GetDefaultMacKey().AlternativeKeyAsBinary);
+
+    public SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKnownIdUtils sourceKnownIdUtils)
+    {
+        _sourceKnownIdUtils = sourceKnownIdUtils;
+        _keyRing = new NexusKeyRing(appSettings.NexusAppSettings);
+        _aes = _keyRing.Default.Aes;
+        _macKey = _keyRing.Default.MacKey;
+        _useSecure = appSettings.NexusAppSettings.UseSecureSourceKnownIds;
+    }
 
     public SourceKnownEntityId Generate<TEntity>(long id) where TEntity : SourceKnownEntity => Generate(id, SourceKnownEntity.GetEntityType<TEntity>());
     public SourceKnownEntityId Generate(SourceKnownEntity entity) => Generate(entity.Id, SourceKnownEntity.GetEntityType(entity));
@@ -140,11 +148,11 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         guidBytes.Clear();
 
         WriteIdAndMarkers(guidBytes, id, entityType, SourceKnownMarkerVariantByte);
-        ComputeMac(guidBytes, hashBytes, _defaultMacKey);
+        ComputeMac(guidBytes, hashBytes, _macKey);
         WriteMacToGuid(guidBytes, hashBytes);
 
         var entityId = new Guid(guidBytes, bigEndian: true);
-        var sourceKnownId = sourceKnownIdUtils.Parse(id);
+        var sourceKnownId = _sourceKnownIdUtils.Parse(id);
 
         return new SourceKnownEntityId(sourceKnownId, entityId, entityType, true, Secure: false);
     }
@@ -154,6 +162,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
     public SourceKnownEntityId GenerateSecure(long id, byte entityType)
     {
+
         Span<byte> hashBytes = stackalloc byte[MacHashLength];
         Span<byte> guidBytes = stackalloc byte[GuidLength];
         guidBytes.Clear();
@@ -161,7 +170,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         // Build guid identically to non-secure (same layout, same markers)
         var variantByte = SourceKnownMarkerVariantByte;
         WriteIdAndMarkers(guidBytes, id, entityType, variantByte);
-        ComputeMac(guidBytes, hashBytes, _defaultMacKey);
+        ComputeMac(guidBytes, hashBytes, _macKey);
         WriteMacToGuid(guidBytes, hashBytes);
 
         // Encrypt entire 16-byte block with AES-ECB (true PRP — no nonce needed)
@@ -172,7 +181,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         // the parse path would misclassify this Secure SKEID as Plain.
         // Fix: iterate variant bytes 0x8E→0xBF — AES avalanche guarantees distinct ciphertext per variant.
         // Deterministic termination: at most 51 iterations. Exhaustion throws JackpotException.
-        if (HasValidMarkers(guidBytes) && HasCoincidentalMacMatch(guidBytes))
+        if (HasValidMarkers(guidBytes) && HasCoincidentalMacMatch(guidBytes, _macKey))
         {
             for (variantByte = SourceKnownMarkerVariantByte + 1;
                  variantByte <= SourceKnownMarkerVariantMaxByte;
@@ -181,11 +190,11 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
                 guidBytes.Clear();
                 hashBytes.Clear();
                 WriteIdAndMarkers(guidBytes, id, entityType, variantByte);
-                ComputeMac(guidBytes, hashBytes, _defaultMacKey);
+                ComputeMac(guidBytes, hashBytes, _macKey);
                 WriteMacToGuid(guidBytes, hashBytes);
                 EncryptGuidBlock(guidBytes, _aes);
 
-                if (!HasValidMarkers(guidBytes) || !HasCoincidentalMacMatch(guidBytes))
+                if (!HasValidMarkers(guidBytes) || !HasCoincidentalMacMatch(guidBytes, _macKey))
                     break;
             }
 
@@ -197,7 +206,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         }
 
         var entityId = new Guid(guidBytes, bigEndian: true);
-        var sourceKnownId = sourceKnownIdUtils.Parse(id);
+        var sourceKnownId = _sourceKnownIdUtils.Parse(id);
 
         return new SourceKnownEntityId(sourceKnownId, entityId, entityType, true, Secure: true);
     }
@@ -206,13 +215,25 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
     public SourceKnownEntityId Parse(Guid entityId)
     {
+        foreach (var key in _keyRing.AllWithDefaultAsFirstItem)
+        {
+            var result = ParseWithKey(entityId, key);
+            if (result.Valid)
+                return result;
+        }
+
+        return CreateInvalid(entityId);
+    }
+
+    private SourceKnownEntityId ParseWithKey(Guid entityId, NexusKeyMaterial key)
+    {
         Span<byte> guidBytes = stackalloc byte[GuidLength];
         entityId.TryWriteBytes(guidBytes, bigEndian: true, out _);
 
         // Try non-secure path first (plaintext 8D8D markers visible)
         if (HasValidMarkers(guidBytes))
         {
-            var result = VerifyAndParse(guidBytes, entityId, secure: false);
+            var result = VerifyAndParse(guidBytes, entityId, secure: false, macKey: key.MacKey);
             if (result.Valid)
                 return result;
 
@@ -223,7 +244,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
         // Try secure path: AES-ECB decrypt full block, then check for markers
         // HasValidMarkersSecure accepts RFC 9562 §4.1 variant range 0x80–0xBF (collision guard uses 0x8D–0xBF)
-        DecryptGuidBlock(guidBytes, _aes);
+        DecryptGuidBlock(guidBytes, key.Aes);
 
         if (!HasValidMarkersSecure(guidBytes)) 
             return CreateInvalid(entityId);
@@ -233,7 +254,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         // Non-default variant → backward collision-guard verification
         if (recoveredVariant is > SourceKnownMarkerVariantByte and <= SourceKnownMarkerVariantMaxByte)
         {
-            if (!VerifyCollisionGuardProof(guidBytes, (byte)(recoveredVariant - 1)))
+            if (!VerifyCollisionGuardProof(guidBytes, (byte)(recoveredVariant - 1), key))
                 return CreateInvalid(entityId);
         }
         else if (recoveredVariant != SourceKnownMarkerVariantByte)
@@ -241,7 +262,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
             return CreateInvalid(entityId);
         }
 
-        return VerifyAndParse(guidBytes, entityId, secure: true);
+        return VerifyAndParse(guidBytes, entityId, secure: true, macKey: key.MacKey);
     }
 
     public SourceKnownEntityId? Validate(Guid? entityId, byte entityType)
@@ -300,11 +321,11 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
            && (guidBytes[SourceKnownMarkerVariantIndex] & 0xC0) == 0x80;
 
     /// <summary>
-    /// Checks whether ciphertext bytes, when interpreted as an plain SKEID,
+    /// Checks whether ciphertext bytes, when interpreted as a plain SKEID,
     /// produce a coincidental MAC match. Used by the collision guard in
     /// <see cref="GenerateSecure(long, byte)"/> to detect the ~1/2^48 edge case.
     /// </summary>
-    private bool HasCoincidentalMacMatch(ReadOnlySpan<byte> ciphertextBytes)
+    private bool HasCoincidentalMacMatch(ReadOnlySpan<byte> ciphertextBytes, BinaryData macKey)
     {
         Span<byte> actualHash = stackalloc byte[MacHashLength];
         Span<byte> expectedHash = stackalloc byte[MacHashLength];
@@ -313,7 +334,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
         ReadMacFromGuid(workingCopy, actualHash);
         ClearMacSlots(workingCopy);
-        ComputeMac(workingCopy, expectedHash, _defaultMacKey);
+        ComputeMac(workingCopy, expectedHash, macKey);
 
         return expectedHash.SequenceEqual(actualHash);
     }
@@ -323,7 +344,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
     /// Reads the SKID upper half from bytes 1–4 (big-endian, sign-toggled) and the split lower half
     /// from byte 5 + bytes 9–11 (big-endian). XOR untoggle restores the original signed representation.
     /// </summary>
-    private SourceKnownEntityId VerifyAndParse(Span<byte> guidBytes, Guid entityId, bool secure)
+    private SourceKnownEntityId VerifyAndParse(Span<byte> guidBytes, Guid entityId, bool secure, BinaryData macKey)
     {
         Span<byte> actualHashBytes = stackalloc byte[MacHashLength];
         Span<byte> expectedHashBytes = stackalloc byte[MacHashLength];
@@ -332,7 +353,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
         // Epoch at byte 0 — covered by MAC; todo: consume in multi-epoch parsing
 
-        // Read upper half (big-endian) and untoggle sign bit for signed sort-order restoration
+        // Read upper half (big-endian) and untoggle the sign bit for signed sort-order restoration
         var idUpperHalf = BinaryPrimitives.ReadUInt32BigEndian(guidBytes.Slice(EntityIdUpperHalfOffset, EntityIdUpperHalfLength)) ^ SignBitToggle;
 
         // Read split lower half: byte 5 (MSB) + bytes 9-11
@@ -349,10 +370,10 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         var id = (long)idBuilder.GetValue();
 
         ClearMacSlots(guidBytes);
-        ComputeMac(guidBytes, expectedHashBytes, _defaultMacKey);
+        ComputeMac(guidBytes, expectedHashBytes, macKey);
 
         return expectedHashBytes.SequenceEqual(actualHashBytes)
-            ? new SourceKnownEntityId(sourceKnownIdUtils.Parse(id), entityId, entityType, true, secure)
+            ? new SourceKnownEntityId(_sourceKnownIdUtils.Parse(id), entityId, entityType, true, secure)
             : CreateInvalid(entityId);
     }
 
@@ -362,7 +383,7 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
     /// Returns true if the previous variant genuinely collided (legitimate escalation).
     /// Called only for non-default variant bytes (recoveredVariant > 0x8D) during Parse.
     /// </summary>
-    private bool VerifyCollisionGuardProof(ReadOnlySpan<byte> decryptedBytes, byte previousVariant)
+    private bool VerifyCollisionGuardProof(ReadOnlySpan<byte> decryptedBytes, byte previousVariant, NexusKeyMaterial key)
     {
         // Read upper half (big-endian) and untoggle sign bit
         var idUpperHalf = BinaryPrimitives.ReadUInt32BigEndian(
@@ -387,12 +408,12 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         reconstructed.Clear();
 
         WriteIdAndMarkers(reconstructed, id, entityType, previousVariant);
-        ComputeMac(reconstructed, hashBytes, _defaultMacKey);
+        ComputeMac(reconstructed, hashBytes, key.MacKey);
         WriteMacToGuid(reconstructed, hashBytes);
-        EncryptGuidBlock(reconstructed, _aes);
+        EncryptGuidBlock(reconstructed, key.Aes);
 
         // Previous variant's ciphertext must have collided (markers + MAC match)
-        return HasValidMarkers(reconstructed) && HasCoincidentalMacMatch(reconstructed);
+        return HasValidMarkers(reconstructed) && HasCoincidentalMacMatch(reconstructed, key.MacKey);
     }
 
     /// <summary>
@@ -457,6 +478,8 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
 
     /// <summary>
     /// Encrypts all 16 guid bytes in-place using AES-256-ECB (single-block PRP).
+    /// EncryptEcb/DecryptEcb are stateless single-block operations safe for concurrent use by this singleton service.
+    /// Stress covered by SourceKnownEntityIdUtilsTests.
     /// For a single 128-bit block, ECB is mathematically identical to CBC with a zero IV
     /// (C = AES(Key, P ⊕ 0) = AES(Key, P)), but avoids the IV allocation and XOR overhead.
     /// ECB's known weakness (identical blocks → identical ciphertexts) does not apply here
@@ -480,22 +503,6 @@ public sealed class SourceKnownEntityIdUtils(IAppSettings appSettings, ISourceKn
         output.CopyTo(guidBytes);
     }
 
-    private static Aes CreateAes(BinaryData key)
-    {
-        var keyBytes = key.ToArray();
-        if (keyBytes.Length != 32)
-            throw new ArgumentException(
-                $"AES-256-ECB requires a 32-byte key but received {keyBytes.Length} bytes. " +
-                $"Verify that AlternativeKeyAsBinary produces a 256-bit key.",
-                nameof(key));
-
-        var aes = Aes.Create();
-        aes.Mode = CipherMode.ECB;
-        aes.Padding = PaddingMode.None;
-        aes.Key = keyBytes;
-
-        return aes;
-    }
-
-    public void Dispose() => _aes.Dispose();
+    // SourceKnownEntityIdUtils is registered as a singleton; the DI container disposes it at shutdown.
+    public void Dispose() => _keyRing.Dispose();
 }

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -672,7 +672,6 @@ Generation uses the default `NexusMacKey`. Parse uses a default-first key-ring f
 > - **Windows (CNG)**: Uses native `BCryptEncrypt` under thread-safe CNG key handles.
 > - **macOS (AppleCommonCrypto)**: Invokes the pure stateless `CCCrypt` function directly.
 > - **Linux (OpenSSL)**: Allocates a temporary `SafeEvpCipherCtxHandle` context inside the call, avoiding instance state mutation.
->
 > Concurrency has been validated via stress tests (`SourceKnownEntityIdUtils_Should_Generate_Ids_For_3_Seconds`) executing ~800,000 parallel operations without data races or corruption.
 
 > [!NOTE]

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -668,6 +668,14 @@ The `Generate` method dispatches to secure or plain generation based on the `Use
 Generation uses the default `NexusMacKey`. Parse uses a default-first key-ring fallback, so IDs generated before key rotation can still be parsed while the previous key remains configured.
 
 > [!NOTE]
+> **Thread-Safety Verification**: Although MSDN documents `Aes` instance members as not guaranteed thread-safe, the span-based one-shot methods `EncryptEcb` and `DecryptEcb` are stateless and fully safe for concurrent execution by this singleton service:
+> - **Windows (CNG)**: Uses native `BCryptEncrypt` under thread-safe CNG key handles.
+> - **macOS (AppleCommonCrypto)**: Invokes the pure stateless `CCCrypt` function directly.
+> - **Linux (OpenSSL)**: Allocates a temporary `SafeEvpCipherCtxHandle` context inside the call, avoiding instance state mutation.
+>
+> Concurrency has been validated via stress tests executing ~800,000 parallel operations without data races or corruption.
+
+> [!NOTE]
 > **Post-quantum readiness**: AES-256 retains 128-bit security under Grover's algorithm — NIST recommended for post-quantum symmetric encryption.
 
 ```csharp

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -673,7 +673,7 @@ Generation uses the default `NexusMacKey`. Parse uses a default-first key-ring f
 > - **macOS (AppleCommonCrypto)**: Invokes the pure stateless `CCCrypt` function directly.
 > - **Linux (OpenSSL)**: Allocates a temporary `SafeEvpCipherCtxHandle` context inside the call, avoiding instance state mutation.
 >
-> Concurrency has been validated via stress tests executing ~800,000 parallel operations without data races or corruption.
+> Concurrency has been validated via stress tests (`SourceKnownEntityIdUtils_Should_Generate_Ids_For_3_Seconds`) executing ~800,000 parallel operations without data races or corruption.
 
 > [!NOTE]
 > **Post-quantum readiness**: AES-256 retains 128-bit security under Grover's algorithm — NIST recommended for post-quantum symmetric encryption.

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -362,6 +362,41 @@ Nested option objects must be validated explicitly before relying on child data 
 > [!TIP]
 > Request buffering and rate limiting settings are consumed by `DRN.Framework.Hosting`. See the [Hosting README](../DRN.Framework.Hosting/README.md) for middleware details.
 
+### NexusAppSettings and MAC Keys
+
+`NexusAppSettings` provides Nexus routing, source-known ID generator identity, secure/plain ID mode, and the MAC key ring used by `SourceKnownEntityIdUtils`.
+
+```json
+{
+  "NexusAppSettings": {
+    "NexusAddress": "localhost:5988",
+    "AppId": 5,
+    "AppInstanceId": 12,
+    "UseSecureSourceKnownIds": true,
+    "MacKeys": [
+      {
+        "Key": "0123456789abcdef0123456789abcdef",
+        "Format": "Utf8",
+        "Default": true
+      }
+    ]
+  }
+}
+```
+
+`MacKeys` must contain exactly one default key. Generation always uses the default key. Parsing tries the default key first and then the remaining configured keys, so old IDs remain parseable during key rotation while the previous key stays in the key ring.
+
+| `ByteEncoding` | Requirement |
+|---------------------|-------------|
+| `Utf8` | Default when omitted. `Key` must be exactly 32 UTF-8 bytes. ASCII 32-character values satisfy this; non-ASCII values are valid only when the UTF-8 byte count is exactly 32. |
+| `Hex` | `Key` must hex-decode to exactly 32 bytes, normally 64 hex characters. A 32-character hex string is rejected because it decodes to 16 bytes. |
+| `Base64` | `Key` must Base64-decode to exactly 32 bytes. |
+| `Base64UrlEncoded` | `Key` must Base64Url-decode to exactly 32 bytes. This is the format produced by the framework `Hash()` default. |
+
+Invalid user-provided keys are not hashed, stretched, truncated, repaired, or treated as another format. Startup validation rejects malformed encodings, empty keys, wrong decoded lengths, and raw values that are not exactly 32 UTF-8 bytes. Exception messages avoid including the secret key value.
+
+When no default MAC key is configured in the `Development` environment, `AppSettings` adds one automatically. This key is deterministic from `DrnAppFeatures.SeedKey`, not random, and is stored in memory as `Format = Base64UrlEncoded`.
+
 ## Logging (`IScopedLog`)
 
 `IScopedLog` provides request-scoped structured logging. It aggregates operational data, metrics, and checkpoints during the request lifecycle, flushing them as a single entry for efficient monitoring.
@@ -629,6 +664,8 @@ The `Generate` method dispatches to secure or plain generation based on the `Use
 | `ToPlain` | Converts a secure ID to its plain form (idempotent) |
 
 **Secure variant** encrypts the entire 16-byte GUID using AES-256-ECB as a pseudo-random permutation (PRP). For a single 128-bit block, ECB is mathematically identical to CBC with a zero IV — no nonce required, no nonce-reuse vulnerability. Key separation ensures BLAKE3 keyed MAC (integrity) and AES-256 (confidentiality) use cryptographically independent keys from the same keyring entry.
+
+Generation uses the default `NexusMacKey`. Parse uses a default-first key-ring fallback, so IDs generated before key rotation can still be parsed while the previous key remains configured.
 
 > [!NOTE]
 > **Post-quantum readiness**: AES-256 retains 128-bit security under Grover's algorithm — NIST recommended for post-quantum symmetric encryption.

--- a/DRN.Framework.Utils/RELEASE-NOTES.md
+++ b/DRN.Framework.Utils/RELEASE-NOTES.md
@@ -11,6 +11,8 @@ Not every version includes changes, features or bug fixes. This project can incr
 *   **Path Security Extensions**: Added `PathExtensions.NormalizeDirectoryPath` (full-path resolution with trailing-separator cleanup) and `IsPathWithinDirectory` (segment-aware containment check using OS-correct path comparison) for safe path validation in file-serving and manifest processing.
 *   **ScopedLog.CopyFrom**: New method on `IScopedLog` for merging log data, exception, and warning state from one scoped log into another with defensive value cloning for mutable collection types.
 *   **Configuration Debug View Redaction**: `ConfigurationDebugView` now redacts sensitive configuration values (connection strings, passwords, secrets, tokens, API keys, credentials) by default. A new `GetDebugView(bool includeRawValues)` overload on `IAppSettings` allows opt-in to raw values, but raw inclusion is only permitted in the Development environment.
+*   **Strict Nexus MAC Key Formats**: `NexusMacKey` now records a `ByteEncoding` `Format` (`Utf8`, `Hex`, `Base64`, or `Base64UrlEncoded`) and accepts only values that resolve directly to exactly 32 bytes. Development auto-generation remains deterministic from `SeedKey` and uses the framework `Hash()` default Base64Url output.
+*   **SourceKnownEntityId Key-Ring Fallback**: `SourceKnownEntityIdUtils` generates with the default Nexus MAC key and parses with a default-first key ring so IDs generated before key rotation remain parseable while old keys stay configured.
 
 ### Bug Fixes
 

--- a/DRN.Framework.Utils/Settings/AppSettings.cs
+++ b/DRN.Framework.Utils/Settings/AppSettings.cs
@@ -83,9 +83,9 @@ public class AppSettings : IAppSettings
         AppKey = securitySettings.AppKey;
 
         if (NexusAppSettings.AppId > SourceKnownIdUtils.MaxAppId)
-            throw new ConfigurationException($"Nexus AppId must be less than 64: NexusAppId: {NexusAppSettings.AppId}");
+            throw new ConfigurationException($"Nexus AppId must be less than or equal to {SourceKnownIdUtils.MaxAppId}: NexusAppId: {NexusAppSettings.AppId}");
         if (NexusAppSettings.AppInstanceId > SourceKnownIdUtils.MaxAppInstanceId)
-            throw new ConfigurationException($"Nexus App Instance Id must be less than 32: NexusAppId: {NexusAppSettings.AppInstanceId}");
+            throw new ConfigurationException($"Nexus App Instance Id must be less than or equal to {SourceKnownIdUtils.MaxAppInstanceId}: NexusAppInstanceId: {NexusAppSettings.AppInstanceId}");
 
         ApplicationNameNormalized = ApplicationName.ToPascalCase();
 
@@ -98,8 +98,8 @@ public class AppSettings : IAppSettings
             //Even if the application is not connected to nexus, we still need to add a default Mac key to make development easier.
             var keyPart1 = Hasher.Hash(("1881" + securitySettings.AppHashKey + securitySettings.AppEncryptionKey + "Forever").ToByteArray()).AsSpan().Encode();
             var keyPart2 = Hasher.Hash(("193∞" + securitySettings.AppHashKey + securitySettings.AppEncryptionKey + "Forever").ToByteArray()).AsSpan().Encode();
-            var key = (keyPart1 + keyPart2 + securitySettings.AppKey).Hash();
-            NexusAppSettings.AddNexusMacKey(new NexusMacKey(key) { Default = true });
+            var key = (keyPart1 + keyPart2 + securitySettings.AppKey).Hash(HashAlgorithm.Blake3, ByteEncoding.Base64UrlEncoded);
+            NexusAppSettings.AddNexusMacKey(new NexusMacKey(key, ByteEncoding.Base64UrlEncoded) { Default = true });
         }
 
         NexusAppSettings.Validate();

--- a/DRN.Framework.Utils/Settings/NexusAppSettings.cs
+++ b/DRN.Framework.Utils/Settings/NexusAppSettings.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json.Serialization;
 using DRN.Framework.Utils.Data.Encodings;
 using DRN.Framework.Utils.Data.Hashing;
 using DRN.Framework.Utils.Data.Validation;
@@ -29,7 +31,7 @@ public class NexusAppSettings
     public IReadOnlyList<NexusMacKey> MacKeys
     {
         get => _macKeys;
-        init => _macKeys = value;
+        init => _macKeys = value ?? [];
     }
 
     public NexusMacKey GetDefaultMacKey() => MacKeys.First(x => x.Default);
@@ -43,43 +45,125 @@ public class NexusAppSettings
 
     public void Validate()
     {
-        if (!MacKeys.Any(k => k.Default))
+        if (MacKeys.Count == 0)
+            throw ExceptionFor.Configuration($"{nameof(NexusAppSettings)}.{nameof(MacKeys)} must contain at least 1 {nameof(NexusMacKey)}");
+
+        for (var index = 0; index < MacKeys.Count; index++)
+        {
+            if (MacKeys[index] is null)
+                throw ExceptionFor.Configuration($"{nameof(NexusAppSettings)}.{nameof(MacKeys)}[{index}] must not be null");
+        }
+
+        var defaultKeyCount = MacKeys.Count(k => k.Default);
+        if (defaultKeyCount == 0)
             throw ExceptionFor.Configuration($"Default {nameof(NexusMacKey)}, not found");
-        if (MacKeys.Count(k => k.Default) != 1)
+        if (defaultKeyCount != 1)
             throw ExceptionFor.Configuration($"Only 1 default {nameof(NexusMacKey)} is allowed");
 
-        foreach (var key in MacKeys)
+        for (var index = 0; index < MacKeys.Count; index++)
+        {
+            var key = MacKeys[index];
             key.ValidateDataAnnotationsThrowIfInvalid();
+            if (!key.IsValid)
+                throw ExceptionFor.Configuration($"{nameof(NexusAppSettings)}.{nameof(MacKeys)}[{index}] must resolve to exactly 32 bytes");
+        }
     }
 }
 
 public class NexusMacKey
 {
-    public NexusMacKey(string key)
+    private const int RequiredKeyByteLength = 32;
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    [JsonConstructor]
+    public NexusMacKey(string key, ByteEncoding format = ByteEncoding.Utf8)
     {
         Key = key;
+        Format = format;
+        KeyAsBinary = DecodeKey(key, format);
         KeyHash = Key.Hash();
-        KeyAsBinary = Key.Decode();
         AlternativeKey = (((KeyHash + "1919").Hash() + "1923").Hash() + "193∞").Hash();
         AlternativeKeyAsBinary = AlternativeKey.Decode();
+
+        if (!IsValid)
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)} must resolve to exactly 32-byte MAC and alternative keys");
     }
 
-    internal NexusMacKey(BinaryData keyAsBinary) : this(keyAsBinary.Encode())
+    internal NexusMacKey(BinaryData keyAsBinary) : this(keyAsBinary.Encode(), ByteEncoding.Base64UrlEncoded)
     {
     }
 
-    internal NexusMacKey(ReadOnlySpan<byte> key) : this(key.Encode())
+    internal NexusMacKey(ReadOnlySpan<byte> key) : this(key.Encode(), ByteEncoding.Base64UrlEncoded)
     {
     }
 
 
     public string Key { get; }
+    public ByteEncoding Format { get; }
+
+    [JsonIgnore]
     public string KeyHash { get; }
 
+    [JsonIgnore]
     public BinaryData KeyAsBinary { get; }
 
+    [JsonIgnore]
     public string AlternativeKey { get; }
+
+    [JsonIgnore]
     public BinaryData AlternativeKeyAsBinary { get; }
+
     public bool Default { get; init; }
-    public bool IsValid => Key.Length == 32;
+
+    [JsonIgnore]
+    public bool IsValid
+        => KeyAsBinary.ToMemory().Length == RequiredKeyByteLength
+           && AlternativeKeyAsBinary.ToMemory().Length == RequiredKeyByteLength;
+
+    private static BinaryData DecodeKey(string key, ByteEncoding format)
+    {
+        if (string.IsNullOrEmpty(key))
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Key)} must not be empty");
+
+        byte[] keyBytes;
+        try
+        {
+            keyBytes = format switch
+            {
+                ByteEncoding.Utf8 => DecodeUtf8(key),
+                ByteEncoding.Hex => Convert.FromHexString(key),
+                ByteEncoding.Base64 => Convert.FromBase64String(key),
+                ByteEncoding.Base64UrlEncoded => key.Decode(ByteEncoding.Base64UrlEncoded).ToArray(),
+                _ => throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Format)} is not supported")
+            };
+        }
+        catch (EncoderFallbackException exception)
+        {
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Key)} must be valid {format} and resolve to exactly 32 bytes", exception);
+        }
+        catch (FormatException exception)
+        {
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Key)} must be valid {format} and resolve to exactly 32 bytes", exception);
+        }
+        catch (ArgumentException exception) when (format is not ByteEncoding.Utf8)
+        {
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Key)} must be valid {format} and resolve to exactly 32 bytes", exception);
+        }
+
+        if (keyBytes.Length != RequiredKeyByteLength)
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Key)} with format {format} must resolve to exactly 32 bytes; resolved length: {keyBytes.Length}");
+
+        return BinaryData.FromBytes(keyBytes);
+    }
+
+    private static byte[] DecodeUtf8(string key)
+    {
+        var byteCount = StrictUtf8.GetByteCount(key);
+        if (byteCount != RequiredKeyByteLength)
+            throw ExceptionFor.Configuration($"{nameof(NexusMacKey)}.{nameof(Key)} with format {ByteEncoding.Utf8} must be exactly 32 UTF-8 bytes");
+
+        var keyBytes = StrictUtf8.GetBytes(key);
+
+        return keyBytes;
+    }
 }

--- a/DRN.Test.Integration/Settings/settings.json
+++ b/DRN.Test.Integration/Settings/settings.json
@@ -11,6 +11,7 @@
     "MacKeys": [
       {
         "Key": "wN2dC5sO7vVkXpQnYqRtJbZaUxLmKoMhH8GfP4yEI0k=",
+        "Format": "Base64",
         "Default": true
       }
     ]

--- a/DRN.Test.Unit/Settings/settings.json
+++ b/DRN.Test.Unit/Settings/settings.json
@@ -12,6 +12,7 @@
     "MacKeys": [
       {
         "Key": "SFnefTwiLUfxc_RCX54vHROJQ50TDvqDdHImA2rvrso",
+        "Format": "Base64UrlEncoded",
         "Default": true
       }
     ]

--- a/DRN.Test.Unit/Tests/Framework/Hosting/MountDir/json-settings/settings-override.json
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/MountDir/json-settings/settings-override.json
@@ -8,6 +8,7 @@
     "MacKeys": [
       {
         "Key": "SFnefTwiLUfxc_RCX54vHROJQ50TDvqDdHImA2rvrso",
+        "Format": "Base64UrlEncoded",
         "Default": true
       }
     ]

--- a/DRN.Test.Unit/Tests/Framework/Utils/AppSettingsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/AppSettingsTests.cs
@@ -1,4 +1,6 @@
 using DRN.Framework.SharedKernel.Enums;
+using DRN.Framework.Utils.Configurations;
+using DRN.Framework.Utils.Data.Encodings;
 
 namespace DRN.Test.Unit.Tests.Framework.Utils;
 
@@ -16,6 +18,37 @@ public class AppSettingsTests
         settings.Environment.Should().Be(AppEnvironment.Development);
         settings.NexusAppSettings.AppId.Should().Be(appId);
         settings.NexusAppSettings.AppInstanceId.Should().Be(appInstanceId);
+    }
+
+    [Fact]
+    public void AppSettings_Should_Generate_Base64Url_MacKey_In_Development_When_Default_Not_Configured()
+    {
+        byte appId = 56;
+        byte appInstanceId = 21;
+
+        var settings = AppSettings.Development(GetCustomSettings(appId, appInstanceId));
+        var defaultMacKey = settings.NexusAppSettings.GetDefaultMacKey();
+
+        defaultMacKey.Default.Should().BeTrue();
+        defaultMacKey.Format.Should().Be(ByteEncoding.Base64UrlEncoded);
+        defaultMacKey.IsValid.Should().BeTrue();
+        defaultMacKey.Key.Decode(ByteEncoding.Base64UrlEncoded).Length.Should().Be(32);
+    }
+
+    [Fact]
+    public void AppSettings_Should_Throw_Configuration_Exception_When_Default_MacKey_Missing_Outside_Development()
+    {
+        var configuration = new ConfigurationManager()
+            .AddObjectToJsonConfiguration(new
+            {
+                Environment = "Staging",
+                NexusAppSettings = new NexusAppSettings { AppId = 1, AppInstanceId = 1 }
+            })
+            .Build();
+
+        var action = () => new AppSettings(configuration);
+
+        action.Should().ThrowExactly<ConfigurationException>();
     }
 
     [Fact]

--- a/DRN.Test.Unit/Tests/Framework/Utils/Ids/IetfTestVectorGeneratorTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Ids/IetfTestVectorGeneratorTests.cs
@@ -23,7 +23,7 @@ public class IetfTestVectorGeneratorTests
         for (var i = 0; i < 32; i++) testKeyBytes[i] = (byte)i;
         var testKeyBase64Url = Base64Url.EncodeToString(testKeyBytes);
 
-        var nexusMacKey = new NexusMacKey(testKeyBase64Url) { Default = true };
+        var nexusMacKey = new NexusMacKey(testKeyBase64Url, ByteEncoding.Base64UrlEncoded) { Default = true };
         var nexusSettings = new NexusAppSettings
         {
             AppId = 5,

--- a/DRN.Test.Unit/Tests/Framework/Utils/Ids/SourceKnownEntityIdUtilsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Ids/SourceKnownEntityIdUtilsTests.cs
@@ -327,6 +327,89 @@ public class SourceKnownEntityIdUtilsTests
         }
     }
 
+    [Fact]
+    public void Parse_Should_Fall_Back_To_Previous_KeyRing_Entries()
+    {
+        var oldKey = new NexusMacKey(new string('A', 32)) { Default = true };
+        var oldSettings = AppSettings.Development(new
+        {
+            NexusAppSettings = new NexusAppSettings
+            {
+                AppId = 5,
+                AppInstanceId = 12,
+                MacKeys = [oldKey]
+            }
+        });
+        var oldIdUtils = new SourceKnownIdUtils(oldSettings, new EpochTimeUtils());
+        using var oldEntityIdUtils = new SourceKnownEntityIdUtils(oldSettings, oldIdUtils);
+
+        var id = SourceKnownIdUtils.Generate<XEntity>(oldSettings.NexusAppSettings.AppId, oldSettings.NexusAppSettings.AppInstanceId);
+        var secureId = oldEntityIdUtils.GenerateSecure<XEntity>(id);
+
+        var rotatedSettings = AppSettings.Development(new
+        {
+            NexusAppSettings = new NexusAppSettings
+            {
+                AppId = 5,
+                AppInstanceId = 12,
+                MacKeys =
+                [
+                    new NexusMacKey(new string('B', 32)) { Default = true },
+                    new NexusMacKey(new string('A', 32))
+                ]
+            }
+        });
+        var rotatedIdUtils = new SourceKnownIdUtils(rotatedSettings, new EpochTimeUtils());
+        using var rotatedEntityIdUtils = new SourceKnownEntityIdUtils(rotatedSettings, rotatedIdUtils);
+
+        var parsed = rotatedEntityIdUtils.Parse(secureId.EntityId);
+
+        parsed.Valid.Should().BeTrue("old IDs must remain parseable while the old key remains in the key ring");
+        parsed.Secure.Should().BeTrue();
+        parsed.EntityType.Should().Be(SourceKnownEntity.GetEntityType<XEntity>());
+        parsed.Source.Id.Should().Be(id);
+    }
+
+    [Fact]
+    public void Generate_Should_Use_Default_Key_When_Default_Is_Not_First()
+    {
+        var settings = AppSettings.Development(new
+        {
+            NexusAppSettings = new NexusAppSettings
+            {
+                AppId = 5,
+                AppInstanceId = 12,
+                MacKeys =
+                [
+                    new NexusMacKey(new string('A', 32)),
+                    new NexusMacKey(new string('B', 32)) { Default = true }
+                ]
+            }
+        });
+        var idUtils = new SourceKnownIdUtils(settings, new EpochTimeUtils());
+        using var entityIdUtils = new SourceKnownEntityIdUtils(settings, idUtils);
+
+        var id = SourceKnownIdUtils.Generate<XEntity>(settings.NexusAppSettings.AppId, settings.NexusAppSettings.AppInstanceId);
+        var secureId = entityIdUtils.GenerateSecure<XEntity>(id);
+
+        var defaultOnlySettings = AppSettings.Development(new
+        {
+            NexusAppSettings = new NexusAppSettings
+            {
+                AppId = 5,
+                AppInstanceId = 12,
+                MacKeys = [new NexusMacKey(new string('B', 32)) { Default = true }]
+            }
+        });
+        var defaultOnlyIdUtils = new SourceKnownIdUtils(defaultOnlySettings, new EpochTimeUtils());
+        using var defaultOnlyEntityIdUtils = new SourceKnownEntityIdUtils(defaultOnlySettings, defaultOnlyIdUtils);
+
+        var parsed = defaultOnlyEntityIdUtils.Parse(secureId.EntityId);
+
+        parsed.Valid.Should().BeTrue("generation must use the configured default key even when it is not first in MacKeys");
+        parsed.Source.Id.Should().Be(id);
+    }
+
     private static void AssertValidEntityId(SourceKnownEntityId entityId, long expectedId,
         NexusAppSettings nexusSettings, byte expectedEntityType, bool expectedSecure)
     {

--- a/DRN.Test.Unit/Tests/Framework/Utils/Settings/NexusMacKeyTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Settings/NexusMacKeyTests.cs
@@ -1,0 +1,168 @@
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json;
+using DRN.Framework.SharedKernel.Json;
+using DRN.Framework.Utils.Data.Encodings;
+
+namespace DRN.Test.Unit.Tests.Framework.Utils.Settings;
+
+public class NexusMacKeyTests
+{
+    private const string Utf8Key = "0123456789abcdef0123456789abcdef";
+    private static readonly byte[] SequentialKeyBytes = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+
+    [Theory]
+    [DataMemberUnit(nameof(ValidKeys))]
+    public void NexusMacKey_Should_Accept_Only_Valid_32Byte_Key_Formats(string key, ByteEncoding format, string expectedHex)
+    {
+        var nexusMacKey = new NexusMacKey(key, format) { Default = true };
+
+        nexusMacKey.Format.Should().Be(format);
+        nexusMacKey.IsValid.Should().BeTrue();
+        Convert.ToHexString(nexusMacKey.KeyAsBinary.ToArray()).Should().Be(expectedHex);
+        nexusMacKey.AlternativeKeyAsBinary.Length.Should().Be(32);
+    }
+
+    [Theory]
+    [DataMemberUnit(nameof(InvalidKeys))]
+    public void NexusMacKey_Should_Reject_Invalid_Key_Formats(string key, ByteEncoding format)
+    {
+        var action = () => new NexusMacKey(key, format);
+
+        var exception = action.Should().Throw<ConfigurationException>().Which;
+        if (!string.IsNullOrEmpty(key))
+            exception.Message.Should().NotContain(key);
+    }
+
+    [Theory]
+    [DataMemberUnit(nameof(ValidKeys))]
+    public void NexusMacKey_Should_RoundTrip_Through_SystemTextJson(string key, ByteEncoding format, string _)
+    {
+        var settings = new NexusAppSettings
+        {
+            MacKeys = [new NexusMacKey(key, format) { Default = true }]
+        };
+
+        var json = JsonSerializer.Serialize(settings, JsonConventions.DefaultOptions);
+        var roundTripped = JsonSerializer.Deserialize<NexusAppSettings>(json, JsonConventions.DefaultOptions);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.MacKeys.Should().ContainSingle();
+        roundTripped.MacKeys[0].Key.Should().Be(key);
+        roundTripped.MacKeys[0].Format.Should().Be(format);
+        roundTripped.MacKeys[0].Default.Should().BeTrue();
+        roundTripped.MacKeys[0].IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NexusMacKey_Should_RoundTrip_With_SystemTextJson_DefaultOptions()
+    {
+        var key = Base64Url.EncodeToString(SequentialKeyBytes);
+        var nexusMacKey = new NexusMacKey(key, ByteEncoding.Base64UrlEncoded) { Default = true };
+
+        var json = JsonSerializer.Serialize(nexusMacKey);
+        var roundTripped = JsonSerializer.Deserialize<NexusMacKey>(json);
+
+        json.Should().Contain(nameof(ByteEncoding.Base64UrlEncoded));
+        roundTripped.Should().NotBeNull();
+        roundTripped!.Key.Should().Be(key);
+        roundTripped.Format.Should().Be(ByteEncoding.Base64UrlEncoded);
+        roundTripped.Default.Should().BeTrue();
+        roundTripped.KeyAsBinary.ToArray().Should().Equal(SequentialKeyBytes);
+    }
+
+    [Fact]
+    public void NexusMacKey_Should_Accept_Utf8_When_ByteCount_Is_Exactly_32()
+    {
+        var key = new string('a', 30) + "ğ";
+
+        var nexusMacKey = new NexusMacKey(key, ByteEncoding.Utf8);
+
+        Encoding.UTF8.GetByteCount(key).Should().Be(32);
+        key.Length.Should().NotBe(32);
+        nexusMacKey.KeyAsBinary.ToArray().Should().Equal(Encoding.UTF8.GetBytes(key));
+    }
+
+    [Fact]
+    public void NexusMacKey_Should_Deserialize_Numeric_Format_With_SystemTextJson()
+    {
+        var json = $$"""
+                     {
+                       "macKeys": [
+                         {
+                           "key": "{{SequentialKeyBytes.Encode(ByteEncoding.Hex)}}",
+                           "format": 1,
+                           "default": true
+                         }
+                       ]
+                     }
+                     """;
+
+        var settings = JsonSerializer.Deserialize<NexusAppSettings>(json, JsonConventions.DefaultOptions);
+
+        settings.Should().NotBeNull();
+        settings!.MacKeys.Should().ContainSingle();
+        settings.MacKeys[0].Format.Should().Be(ByteEncoding.Hex);
+        settings.MacKeys[0].KeyAsBinary.ToArray().Should().Equal(SequentialKeyBytes);
+    }
+
+    [Fact]
+    public void NexusMacKey_Should_Bind_Format_From_Configuration()
+    {
+        var key = Base64Url.EncodeToString(SequentialKeyBytes);
+        var configuration = new ConfigurationManager()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NexusAppSettings:MacKeys:0:Key"] = key,
+                ["NexusAppSettings:MacKeys:0:Format"] = nameof(ByteEncoding.Base64UrlEncoded),
+                ["NexusAppSettings:MacKeys:0:Default"] = bool.TrueString
+            })
+            .Build();
+
+        var settings = configuration.GetSection(nameof(NexusAppSettings)).Get<NexusAppSettings>();
+
+        settings.Should().NotBeNull();
+        settings!.Validate();
+        settings.MacKeys.Should().ContainSingle();
+        settings.MacKeys[0].Format.Should().Be(ByteEncoding.Base64UrlEncoded);
+        settings.MacKeys[0].KeyAsBinary.ToArray().Should().Equal(SequentialKeyBytes);
+    }
+
+    public static IEnumerable<object[]> ValidKeys()
+    {
+        yield return
+        [
+            Utf8Key,
+            ByteEncoding.Utf8,
+            Convert.ToHexString(Encoding.UTF8.GetBytes(Utf8Key))
+        ];
+        yield return
+        [
+            SequentialKeyBytes.Encode(ByteEncoding.Hex),
+            ByteEncoding.Hex,
+            Convert.ToHexString(SequentialKeyBytes)
+        ];
+        yield return
+        [
+            Convert.ToBase64String(SequentialKeyBytes),
+            ByteEncoding.Base64,
+            Convert.ToHexString(SequentialKeyBytes)
+        ];
+        yield return
+        [
+            Base64Url.EncodeToString(SequentialKeyBytes),
+            ByteEncoding.Base64UrlEncoded,
+            Convert.ToHexString(SequentialKeyBytes)
+        ];
+    }
+
+    public static IEnumerable<object[]> InvalidKeys()
+    {
+        yield return ["1019464a0c19475693c155fcb0f7b3e8", ByteEncoding.Hex];
+        yield return [Convert.ToBase64String(new byte[16]), ByteEncoding.Base64];
+        yield return [Base64Url.EncodeToString(new byte[24]), ByteEncoding.Base64UrlEncoded];
+        yield return ["", ByteEncoding.Utf8];
+        yield return ["ğ123456789abcdef0123456789abcdef", ByteEncoding.Utf8];
+        yield return ["not-a-valid-base64", ByteEncoding.Base64];
+    }
+}

--- a/Sample.Hosted/appsettings.Development.json
+++ b/Sample.Hosted/appsettings.Development.json
@@ -5,10 +5,13 @@
     "RequireConfirmedPhoneNumber": false
   },
   "NexusAppSettings": {
-    "Address": "localhost:5988"
+    "NexusAddress": "localhost:5988",
+    "MacKeyFormatNote": "If a MacKeys entry is configured, Format defaults to Utf8 when omitted.",
+    "MacKeyAlternativeFormatNote": "Alternative MacKey formats: Hex, Base64, or Base64UrlEncoded; decoded bytes must be exactly 32."
   },
   "DrnAppFeatures": {
     "InternalRequestHttpVersion": "1.1",
+    "SeedKeyNote": "Development default Nexus MAC key is deterministic. When no default NexusAppSettings:MacKeys entry is configured, AppSettings derives AppHashKey, AppEncryptionKey and AppKey from this SeedKey, then hashes those values into a Base64UrlEncoded 32-byte MAC key. Changing SeedKey changes that generated key and IDs created with the previous key will require the previous key in MacKeys for parsing.",
     "SeedKey": "Our true mentor in life is science! - Mustafa Kemal Atatürk (1924)",
     "DrnRateLimit": {
       "TokenLimit": 20,

--- a/Sample.Hosted/appsettings.Staging.json
+++ b/Sample.Hosted/appsettings.Staging.json
@@ -8,11 +8,11 @@
   },
   "NexusAppSettings": {
     "MacKeyExampleNote": "The checked-in staging MAC key is an example only. Override it with secret configuration before using any shared, exposed, or production-like environment.",
-    "MacKeyFormatNote": "Format is omitted intentionally. NexusMacKey defaults to ByteEncoding.Utf8, so this 32-character hyphenless GUID string is used as 32 raw UTF-8 bytes and is not hex-decoded.",
+    "MacKeyFormatNote": "Format is omitted intentionally. NexusMacKey defaults to ByteEncoding.Utf8, so this 32-character sample string is used as 32 raw UTF-8 bytes and is not hex-decoded.",
     "MacKeyAlternativeFormatNote": "Alternative MacKey formats: Hex, Base64, or Base64UrlEncoded; decoded bytes must be exactly 32.",
     "MacKeys": [
       {
-        "Key": "570DC5349C6D49E9A38D074DA5B3A5F9",
+        "Key": "sample-mac-key-00000000000000000",
         "Default": true
       }
     ]

--- a/Sample.Hosted/appsettings.Staging.json
+++ b/Sample.Hosted/appsettings.Staging.json
@@ -1,0 +1,24 @@
+{
+  "Environment": "Staging",
+  "AllowedHosts": "localhost;127.0.0.1;[::1];sample;drn-sample",
+  "Identity": {
+    "RequireConfirmedAccount": false,
+    "RequireConfirmedEmail": false,
+    "RequireConfirmedPhoneNumber": false
+  },
+  "NexusAppSettings": {
+    "MacKeyExampleNote": "The checked-in staging MAC key is an example only. Override it with secret configuration before using any shared, exposed, or production-like environment.",
+    "MacKeyFormatNote": "Format is omitted intentionally. NexusMacKey defaults to ByteEncoding.Utf8, so this 32-character hyphenless GUID string is used as 32 raw UTF-8 bytes and is not hex-decoded.",
+    "MacKeyAlternativeFormatNote": "Alternative MacKey formats: Hex, Base64, or Base64UrlEncoded; decoded bytes must be exactly 32.",
+    "MacKeys": [
+      {
+        "Key": "570DC5349C6D49E9A38D074DA5B3A5F9",
+        "Default": true
+      }
+    ]
+  },
+  "DrnAppFeatures": {
+    "SeedKeyNote": "This staging example uses the same SeedKey as Development. Staging requires an explicit default MacKey; changing SeedKey does not change this configured MacKey.",
+    "SeedKey": "Our true mentor in life is science! - Mustafa Kemal Atatürk (1924)"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,11 @@ services:
       Identity__RequireConfirmedEmail: ${Identity__RequireConfirmedEmail:-false}
       Identity__RequireConfirmedPhoneNumber: ${Identity__RequireConfirmedPhoneNumber:-false}
       DrnDevelopmentSettings__AutoMigrateStaging: ${DrnDevelopmentSettings__AutoMigrateStaging:-true}
+      # Development without an explicit default MacKey derives one deterministically from DrnAppFeatures__SeedKey.
+      # Changing SeedKey changes generated IDs unless the previous key remains in NexusAppSettings__MacKeys.
+      # Alternative MacKey formats: set Format to Hex, Base64, or Base64UrlEncoded; decoded bytes must be exactly 32.
       NexusAppSettings__MacKeys__0__Key: ${NexusAppSettings__MacKeys__0__Key:?configure in the .env file}
+      NexusAppSettings__MacKeys__0__Format: ${NexusAppSettings__MacKeys__0__Format:-Utf8}
       NexusAppSettings__MacKeys__0__Default: ${NexusAppSettings__MacKeys__0__Default:-true}
       ConnectionStrings__DrnDataProtectionContext: *sample-postgres-connection
       ConnectionStrings__QAContext: *sample-postgres-connection


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable MAC key encoding format (Utf8/Hex/Base64/Base64Url) with strict 32-byte material requirements.
  * Key-ring based MAC/AES handling enables key-rotation parsing with default-first fallback.
  * Development mode can deterministically generate a default MAC key when none is configured.
* **Documentation**
  * Updated settings and SourceKnownEntityId generation/parse guidance, rotation behavior, and format rules.
* **Improvements**
  * Hardened configuration validation and clearer validation behavior for decoded byte lengths.
* **Tests**
  * Added coverage for MAC key validation/serialization and key-rotation parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->