### PR TITLE
security(Utils): introduce SecretKey32 with zero-memory disposal

### DIFF
--- a/.agent/skills/drn-utils/SKILL.md
+++ b/.agent/skills/drn-utils/SKILL.md
@@ -144,7 +144,6 @@ When grouping options into nested objects, explicitly validate child objects bef
 | `Base64` | Base64 decodes to exactly 32 bytes. |
 | `Base64UrlEncoded` | Base64Url decodes to exactly 32 bytes. |
 
-Do not hash, pad, truncate, auto-detect, or repair configured key material before decoding. After validation, `NexusKey` derives separate 32-byte `MacKey` and `EncryptionKey` values from decoded key material through BLAKE3 derive-key mode with distinct DRN Framework context strings. In `Development`, when no default Nexus key is configured, `AppSettings` deterministically derives Base64Url key material from `AppSecuritySettings` context-derived values with BLAKE3 derive-key mode; `DrnAppFeatures.SeedKey` feeds `AppSecuritySettings`, and the generated key material then goes through the same `NexusKey` BLAKE3 derive-key separation.
 
 ---
 

--- a/DRN.Framework.Utils/Data/Encryption/NexusKeyRing.cs
+++ b/DRN.Framework.Utils/Data/Encryption/NexusKeyRing.cs
@@ -7,13 +7,30 @@ internal sealed class NexusKeyRing : IDisposable
     public NexusKeyRing(NexusAppSettings settings)
     {
         var defaultNexusKey = settings.GetDefaultKey();
-        Default = new NexusSecret(defaultNexusKey);
-        Fallback = settings.Keys
-            .Where(key => !key.Default)
-            .Select(key => new NexusSecret(key))
-            .ToArray();
+        var createdSecrets = new List<NexusSecret>();
+        try
+        {
+            var defaultSecret = new NexusSecret(defaultNexusKey);
+            createdSecrets.Add(defaultSecret);
+            Default = defaultSecret;
 
-        AllWithDefaultAsFirstItem = [Default, ..Fallback];
+            var fallbackList = new List<NexusSecret>();
+            foreach (var key in settings.Keys.Where(key => !key.Default))
+            {
+                var secret = new NexusSecret(key);
+                createdSecrets.Add(secret);
+                fallbackList.Add(secret);
+            }
+
+            Fallback = fallbackList.ToArray();
+            AllWithDefaultAsFirstItem = [Default, ..Fallback];
+        }
+        catch
+        {
+            foreach (var secret in createdSecrets)
+                secret.Dispose();
+            throw;
+        }
     }
 
     public NexusSecret Default { get; }

--- a/DRN.Framework.Utils/Data/Encryption/NexusKeyRing.cs
+++ b/DRN.Framework.Utils/Data/Encryption/NexusKeyRing.cs
@@ -7,18 +7,18 @@ internal sealed class NexusKeyRing : IDisposable
     public NexusKeyRing(NexusAppSettings settings)
     {
         var defaultNexusKey = settings.GetDefaultKey();
-        Default = new NexusKeyMaterial(defaultNexusKey);
+        Default = new NexusSecret(defaultNexusKey);
         Fallback = settings.Keys
             .Where(key => !key.Default)
-            .Select(key => new NexusKeyMaterial(key))
+            .Select(key => new NexusSecret(key))
             .ToArray();
 
         AllWithDefaultAsFirstItem = [Default, ..Fallback];
     }
 
-    public NexusKeyMaterial Default { get; }
-    public IReadOnlyList<NexusKeyMaterial> Fallback { get; }
-    public IReadOnlyList<NexusKeyMaterial> AllWithDefaultAsFirstItem { get; }
+    public NexusSecret Default { get; }
+    public IReadOnlyList<NexusSecret> Fallback { get; }
+    public IReadOnlyList<NexusSecret> AllWithDefaultAsFirstItem { get; }
 
     public void Dispose()
     {

--- a/DRN.Framework.Utils/Data/Encryption/NexusSecret.cs
+++ b/DRN.Framework.Utils/Data/Encryption/NexusSecret.cs
@@ -3,14 +3,28 @@ using DRN.Framework.Utils.Settings;
 
 namespace DRN.Framework.Utils.Data.Encryption;
 
-internal sealed class NexusSecret(NexusKey key) : IDisposable
+internal sealed class NexusSecret : IDisposable
 {
+    public NexusSecret(NexusKey key)
+    {
+        MacKey = new SecretKey32(key.MacKey.Span);
+        try
+        {
+            Aes = CreateAes(key.EncryptionKey);
+        }
+        catch
+        {
+            MacKey.Dispose();
+            throw;
+        }
+    }
+
     // MacKey is BLAKE3-derived material used only for keyed MAC integrity checks.
-    internal SecretKey32 MacKey { get; } = new(key.MacKey.Span);
+    internal SecretKey32 MacKey { get; }
 
     // EncryptionKey is separate BLAKE3-derived 32-byte material used only for AES-256 encryption.
     // AES-256 retains 128-bit security under Grover's algorithm and is suitable for post-quantum symmetric strength.
-    internal Aes Aes { get; } = CreateAes(key.EncryptionKey);
+    internal Aes Aes { get; }
 
     public void Dispose()
     {

--- a/DRN.Framework.Utils/Data/Encryption/NexusSecret.cs
+++ b/DRN.Framework.Utils/Data/Encryption/NexusSecret.cs
@@ -3,18 +3,22 @@ using DRN.Framework.Utils.Settings;
 
 namespace DRN.Framework.Utils.Data.Encryption;
 
-internal sealed class NexusKeyMaterial(NexusKey key) : IDisposable
+internal sealed class NexusSecret(NexusKey key) : IDisposable
 {
     // MacKey is BLAKE3-derived material used only for keyed MAC integrity checks.
-    public BinaryData MacKey { get; } = key.MacKey;
+    internal SecretKey32 MacKey { get; } = new(key.MacKey.Span);
 
     // EncryptionKey is separate BLAKE3-derived 32-byte material used only for AES-256 encryption.
     // AES-256 retains 128-bit security under Grover's algorithm and is suitable for post-quantum symmetric strength.
-    public Aes Aes { get; } = CreateAes(key.EncryptionKey);
+    internal Aes Aes { get; } = CreateAes(key.EncryptionKey);
 
-    public void Dispose() => Aes.Dispose();
+    public void Dispose()
+    {
+        MacKey.Dispose();
+        Aes.Dispose();
+    }
 
-    private static Aes CreateAes(BinaryData key)
+    private static Aes CreateAes(SecretKey32 key)
     {
         if (key.Length != 32)
             throw new ArgumentException(
@@ -22,9 +26,17 @@ internal sealed class NexusKeyMaterial(NexusKey key) : IDisposable
                 nameof(key));
 
         var aes = Aes.Create();
-        aes.Mode = CipherMode.ECB;
-        aes.Padding = PaddingMode.None;
-        aes.Key = key.ToArray();
+        try
+        {
+            aes.Mode = CipherMode.ECB;
+            aes.Padding = PaddingMode.None;
+            aes.Key = key.Bytes;
+        }
+        catch
+        {
+            aes.Dispose();
+            throw;
+        }
 
         return aes;
     }

--- a/DRN.Framework.Utils/Data/Encryption/SecretKey32.cs
+++ b/DRN.Framework.Utils/Data/Encryption/SecretKey32.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Threading;
 
 namespace DRN.Framework.Utils.Data.Encryption;
 

--- a/DRN.Framework.Utils/Data/Encryption/SecretKey32.cs
+++ b/DRN.Framework.Utils/Data/Encryption/SecretKey32.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+using System.Threading;
+
+namespace DRN.Framework.Utils.Data.Encryption;
+
+/// <summary>
+/// Owns fixed-size 32-byte secret key material.
+/// </summary>
+/// <remarks>
+/// The input is copied on construction. Internal accessors return read-only views or the owned buffer, and disposal clears the owned array.
+/// </remarks>
+internal sealed class SecretKey32 : IDisposable
+{
+    internal const int KeyLength = 32;
+
+    private byte[]? _bytes;
+
+    internal SecretKey32(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length != KeyLength)
+            throw new ArgumentException($"Secret key material must be exactly {KeyLength} bytes; received {bytes.Length}.", nameof(bytes));
+
+        _bytes = bytes.ToArray();
+    }
+
+    internal int Length => Bytes.Length;
+
+    internal ReadOnlySpan<byte> Span => Bytes;
+
+    internal ReadOnlyMemory<byte> Memory => Bytes;
+    
+    internal byte[] Bytes => _bytes ?? throw new ObjectDisposedException(nameof(SecretKey32));
+
+    ~SecretKey32() => ZeroAndRelease();
+    
+    public void Dispose()
+    {
+        ZeroAndRelease();
+        GC.SuppressFinalize(this);
+    }
+
+    private void ZeroAndRelease()
+    {
+        var bytes = Interlocked.Exchange(ref _bytes, null);
+        if (bytes is null)
+            return;
+
+        CryptographicOperations.ZeroMemory(bytes);
+    }
+}

--- a/DRN.Framework.Utils/Data/Hashing/Blake3KeyDerivation.cs
+++ b/DRN.Framework.Utils/Data/Hashing/Blake3KeyDerivation.cs
@@ -1,4 +1,6 @@
+using System.Security.Cryptography;
 using Blake3;
+using DRN.Framework.Utils.Data.Encryption;
 
 namespace DRN.Framework.Utils.Data.Hashing;
 
@@ -11,18 +13,25 @@ namespace DRN.Framework.Utils.Data.Hashing;
 /// </remarks>
 internal static class Blake3KeyDerivation
 {
-    public const int KeyLength = 32;
+    internal const int KeyLength = SecretKey32.KeyLength;
 
-    public static BinaryData Derive32ByteKey(ReadOnlySpan<byte> keyMaterial, string context)
+    internal static SecretKey32 Derive32ByteKey(ReadOnlySpan<byte> keyMaterial, string context)
     {
         Span<byte> derived = stackalloc byte[KeyLength];
-        using var hasher = Hasher.NewDeriveKey(context);
-        hasher.Update(keyMaterial);
-        hasher.Finalize(derived);
+        try
+        {
+            using var hasher = Hasher.NewDeriveKey(context);
+            hasher.Update(keyMaterial);
+            hasher.Finalize(derived);
 
-        return BinaryData.FromBytes(derived.ToArray());
+            return new SecretKey32(derived);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(derived);
+        }
     }
 
-    public static BinaryData Derive32ByteKey(BinaryData keyMaterial, string context)
-        => Derive32ByteKey(keyMaterial.ToMemory().Span, context);
+    internal static SecretKey32 Derive32ByteKey(SecretKey32 keyMaterial, string context)
+        => Derive32ByteKey(keyMaterial.Span, context);
 }

--- a/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
+++ b/DRN.Framework.Utils/Ids/SourceKnownEntityIdUtils.cs
@@ -118,7 +118,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     // MacKey -> BLAKE3 keyed MAC (integrity). EncryptionKey -> AES-256-ECB (confidentiality).
     private readonly NexusKeyRing _keyRing;
     private readonly Aes _aes;
-    private readonly BinaryData _macKey;
+    private readonly SecretKey32 _macKey;
     private readonly bool _useSecure;
     private readonly ISourceKnownIdUtils _sourceKnownIdUtils;
 
@@ -135,8 +135,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     public SourceKnownEntityId Generate<TEntity>(long id) where TEntity : SourceKnownEntity => Generate(id, SourceKnownEntity.GetEntityType<TEntity>());
     public SourceKnownEntityId Generate(SourceKnownEntity entity) => Generate(entity.Id, SourceKnownEntity.GetEntityType(entity));
 
-    public SourceKnownEntityId Generate(long id, byte entityType)
-        => _useSecure ? GenerateSecure(id, entityType) : GeneratePlain(id, entityType);
+    public SourceKnownEntityId Generate(long id, byte entityType) => _useSecure ? GenerateSecure(id, entityType) : GeneratePlain(id, entityType);
 
     public SourceKnownEntityId GeneratePlain<TEntity>(long id) where TEntity : SourceKnownEntity => GeneratePlain(id, SourceKnownEntity.GetEntityType<TEntity>());
     public SourceKnownEntityId GeneratePlain(SourceKnownEntity entity) => GeneratePlain(entity.Id, SourceKnownEntity.GetEntityType(entity));
@@ -225,7 +224,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
         return CreateInvalid(entityId);
     }
 
-    private SourceKnownEntityId ParseWithKey(Guid entityId, NexusKeyMaterial key)
+    private SourceKnownEntityId ParseWithKey(Guid entityId, NexusSecret key)
     {
         Span<byte> guidBytes = stackalloc byte[GuidLength];
         entityId.TryWriteBytes(guidBytes, bigEndian: true, out _);
@@ -258,9 +257,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
                 return CreateInvalid(entityId);
         }
         else if (recoveredVariant != SourceKnownMarkerVariantByte)
-        {
             return CreateInvalid(entityId);
-        }
 
         return VerifyAndParse(guidBytes, entityId, secure: true, macKey: key.MacKey);
     }
@@ -305,7 +302,8 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     public SourceKnownEntityId? ToPlain(SourceKnownEntityId? id)
         => id.HasValue ? ToPlain(id.Value) : null;
 
-    private static SourceKnownEntityId CreateInvalid(Guid entityId) => new(default, entityId, InvalidEntityType, false, Secure: false);
+    private static SourceKnownEntityId CreateInvalid(Guid entityId) 
+        => new(default, entityId, InvalidEntityType, false, Secure: false);
 
     private static bool HasValidMarkers(ReadOnlySpan<byte> guidBytes)
         => guidBytes[SourceKnownMarkerVersionIndex] == SourceKnownMarkerVersionByte
@@ -325,7 +323,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     /// produce a coincidental MAC match. Used by the collision guard in
     /// <see cref="GenerateSecure(long, byte)"/> to detect the ~1/2^48 edge case.
     /// </summary>
-    private static bool HasCoincidentalMacMatch(ReadOnlySpan<byte> ciphertextBytes, BinaryData macKey)
+    private static bool HasCoincidentalMacMatch(ReadOnlySpan<byte> ciphertextBytes, SecretKey32 macKey)
     {
         Span<byte> actualHash = stackalloc byte[MacHashLength];
         Span<byte> expectedHash = stackalloc byte[MacHashLength];
@@ -344,7 +342,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     /// Reads the SKID upper half from bytes 1–4 (big-endian, sign-toggled) and the split lower half
     /// from byte 5 + bytes 9–11 (big-endian). XOR untoggle restores the original signed representation.
     /// </summary>
-    private SourceKnownEntityId VerifyAndParse(Span<byte> guidBytes, Guid entityId, bool secure, BinaryData macKey)
+    private SourceKnownEntityId VerifyAndParse(Span<byte> guidBytes, Guid entityId, bool secure, SecretKey32 macKey)
     {
         Span<byte> actualHashBytes = stackalloc byte[MacHashLength];
         Span<byte> expectedHashBytes = stackalloc byte[MacHashLength];
@@ -383,7 +381,7 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     /// Returns true if the previous variant genuinely collided (legitimate escalation).
     /// Called only for non-default variant bytes (recoveredVariant > 0x8D) during Parse.
     /// </summary>
-    private static bool VerifyCollisionGuardProof(ReadOnlySpan<byte> decryptedBytes, byte previousVariant, NexusKeyMaterial key)
+    private static bool VerifyCollisionGuardProof(ReadOnlySpan<byte> decryptedBytes, byte previousVariant, NexusSecret key)
     {
         // Read upper half (big-endian) and untoggle sign bit
         var idUpperHalf = BinaryPrimitives.ReadUInt32BigEndian(
@@ -445,9 +443,9 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     /// <summary>
     /// Computes BLAKE3 keyed MAC over the guid bytes (MAC slots must be zeroed before calling).
     /// </summary>
-    private static void ComputeMac(ReadOnlySpan<byte> guidBytes, Span<byte> hashBytes, BinaryData macKey)
+    private static void ComputeMac(ReadOnlySpan<byte> guidBytes, Span<byte> hashBytes, SecretKey32 macKey)
     {
-        using var hasher = Hasher.NewKeyed(macKey);
+        using var hasher = Hasher.NewKeyed(macKey.Span);
         hasher.Update(guidBytes);
         hasher.Finalize(hashBytes);
     }
@@ -455,26 +453,20 @@ public sealed class SourceKnownEntityIdUtils : ISourceKnownEntityIdUtils, IDispo
     /// <summary>
     /// Writes 4-byte MAC hash into guid byte positions 12-15 (contiguous).
     /// </summary>
-    private static void WriteMacToGuid(Span<byte> guidBytes, ReadOnlySpan<byte> hashBytes)
-    {
-        hashBytes[..MacHashLength].CopyTo(guidBytes[MacHashOffset..]);
-    }
+    private static void WriteMacToGuid(Span<byte> guidBytes, ReadOnlySpan<byte> hashBytes) 
+        => hashBytes[..MacHashLength].CopyTo(guidBytes[MacHashOffset..]);
 
     /// <summary>
     /// Reads 4-byte MAC hash from guid byte positions 12-15 (contiguous).
     /// </summary>
-    private static void ReadMacFromGuid(ReadOnlySpan<byte> guidBytes, Span<byte> hashBytes)
-    {
-        guidBytes[MacHashOffset..(MacHashOffset + MacHashLength)].CopyTo(hashBytes);
-    }
+    private static void ReadMacFromGuid(ReadOnlySpan<byte> guidBytes, Span<byte> hashBytes) 
+        => guidBytes[MacHashOffset..(MacHashOffset + MacHashLength)].CopyTo(hashBytes);
 
     /// <summary>
     /// Zeros the MAC slots (bytes 12-15) in the guid bytes for MAC re-computation.
     /// </summary>
-    private static void ClearMacSlots(Span<byte> guidBytes)
-    {
-        guidBytes[MacHashOffset..(MacHashOffset + MacHashLength)].Clear();
-    }
+    private static void ClearMacSlots(Span<byte> guidBytes) 
+        => guidBytes[MacHashOffset..(MacHashOffset + MacHashLength)].Clear();
 
     /// <summary>
     /// Encrypts all 16 guid bytes in-place using AES-256-ECB (single-block PRP).

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -397,7 +397,6 @@ Nested option objects must be validated explicitly before relying on child data 
 
 Invalid user-provided keys are not hashed, stretched, truncated, repaired, or treated as another format. Startup validation rejects malformed encodings, empty keys, wrong decoded lengths, and raw values that are not exactly 32 UTF-8 bytes. Exception messages avoid including the secret key value.
 
-After format validation, `NexusKey` derives `MacKey` and `EncryptionKey` from the decoded 32 raw bytes through BLAKE3 derive-key mode with distinct DRN Framework context strings. Hex, Base64, and Base64Url text are never hashed as UTF-8 key bytes, so equivalent raw key material derives the same MAC and AES key material in every supported format.
 
 When no default Nexus key is configured in the `Development` environment, `AppSettings` derives deterministic 32-byte key material from `AppSecuritySettings` context-derived values with BLAKE3 derive-key mode. `DrnAppFeatures.SeedKey` feeds `AppSecuritySettings`. The generated key material is not random, is stored in memory as `Format = Base64UrlEncoded`, and then goes through the same BLAKE3 derive-key separation as configured keys.
 

--- a/DRN.Framework.Utils/Settings/AppSecuritySettings.cs
+++ b/DRN.Framework.Utils/Settings/AppSecuritySettings.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Security.Cryptography;
 using System.Text;
 using DRN.Framework.Utils.Data.Encodings;
 using DRN.Framework.Utils.Data.Hashing;
@@ -42,10 +43,17 @@ public class AppSecuritySettings : IAppSecuritySettings
     {
         var seedKey = Encoding.UTF8.GetBytes(features.SeedKey);
 
-        AppHashKey = DeriveBase64UrlKey(seedKey, AppHashKeyDerivationContext);
-        AppEncryptionKey = DeriveBase64UrlKey(seedKey, AppEncryptionKeyDerivationContext);
-        AppKey = DeriveBase64UrlKey(seedKey, AppKeyDerivationContext)[..8];
-        AppSeed = DeriveSeed(seedKey);
+        try
+        {
+            AppHashKey = DeriveBase64UrlKey(seedKey, AppHashKeyDerivationContext);
+            AppEncryptionKey = DeriveBase64UrlKey(seedKey, AppEncryptionKeyDerivationContext);
+            AppKey = DeriveBase64UrlKey(seedKey, AppKeyDerivationContext)[..8];
+            AppSeed = DeriveSeed(seedKey);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(seedKey);
+        }
     }
 
     /// <summary>
@@ -66,12 +74,16 @@ public class AppSecuritySettings : IAppSecuritySettings
     public long AppSeed { get; }
 
     private static string DeriveBase64UrlKey(ReadOnlySpan<byte> keyMaterial, string context)
-        => Blake3KeyDerivation.Derive32ByteKey(keyMaterial, context).Encode(ByteEncoding.Base64UrlEncoded);
+    {
+        using var derivedKey = Blake3KeyDerivation.Derive32ByteKey(keyMaterial, context);
+
+        return derivedKey.Span.Encode(ByteEncoding.Base64UrlEncoded);
+    }
 
     private static long DeriveSeed(ReadOnlySpan<byte> keyMaterial)
     {
-        var seed = Blake3KeyDerivation.Derive32ByteKey(keyMaterial, AppSeedDerivationContext);
+        using var seed = Blake3KeyDerivation.Derive32ByteKey(keyMaterial, AppSeedDerivationContext);
 
-        return BinaryPrimitives.ReadInt64LittleEndian(seed.ToMemory().Span);
+        return BinaryPrimitives.ReadInt64LittleEndian(seed.Span);
     }
 }

--- a/DRN.Framework.Utils/Settings/AppSettings.cs
+++ b/DRN.Framework.Utils/Settings/AppSettings.cs
@@ -84,30 +84,38 @@ public class AppSettings : IAppSettings, IDisposable
         DevelopmentSettings.ValidateDataAnnotationsThrowIfInvalid();
 
         NexusAppSettings = Get<NexusAppSettings>(nameof(NexusAppSettings)) ?? new NexusAppSettings();
-        ThrowIfLegacyNexusMacKeysConfigured();
-        var securitySettings = new AppSecuritySettings(Features);
-        AppKey = securitySettings.AppKey;
-
-        if (NexusAppSettings.AppId > SourceKnownIdUtils.MaxAppId)
-            throw ExceptionFor.Configuration($"Nexus AppId must be less than or equal to {SourceKnownIdUtils.MaxAppId}: NexusAppId: {NexusAppSettings.AppId}");
-        if (NexusAppSettings.AppInstanceId > SourceKnownIdUtils.MaxAppInstanceId)
-            throw ExceptionFor.Configuration(
-                $"Nexus App Instance Id must be less than or equal to {SourceKnownIdUtils.MaxAppInstanceId}: NexusAppInstanceId: {NexusAppSettings.AppInstanceId}");
-
-        ApplicationNameNormalized = ApplicationName.ToPascalCase();
-
-        var hasDefaultNexusKey = NexusAppSettings.HasDefaultKey();
-        if (!hasDefaultNexusKey)
+        try
         {
-            if (Environment != AppEnvironment.Development)
-                throw ExceptionFor.Configuration($"Default Nexus key not found for the environment: {Environment.ToString()}");
+            ThrowIfLegacyNexusMacKeysConfigured();
+            var securitySettings = new AppSecuritySettings(Features);
+            AppKey = securitySettings.AppKey;
 
-            // Even if the application is not connected to Nexus, development still needs deterministic key material.
-            var keyMaterial = DeriveDevelopmentNexusKeyMaterial(securitySettings);
-            NexusAppSettings.AddNexusKey(new NexusKey(keyMaterial, ByteEncoding.Base64UrlEncoded) { Default = true });
+            if (NexusAppSettings.AppId > SourceKnownIdUtils.MaxAppId)
+                throw ExceptionFor.Configuration($"Nexus AppId must be less than or equal to {SourceKnownIdUtils.MaxAppId}: NexusAppId: {NexusAppSettings.AppId}");
+            if (NexusAppSettings.AppInstanceId > SourceKnownIdUtils.MaxAppInstanceId)
+                throw ExceptionFor.Configuration(
+                    $"Nexus App Instance Id must be less than or equal to {SourceKnownIdUtils.MaxAppInstanceId}: NexusAppInstanceId: {NexusAppSettings.AppInstanceId}");
+
+            ApplicationNameNormalized = ApplicationName.ToPascalCase();
+
+            var hasDefaultNexusKey = NexusAppSettings.HasDefaultKey();
+            if (!hasDefaultNexusKey)
+            {
+                if (Environment != AppEnvironment.Development)
+                    throw ExceptionFor.Configuration($"Default Nexus key not found for the environment: {Environment.ToString()}");
+
+                // Even if the application is not connected to Nexus, development still needs deterministic key material.
+                var keyMaterial = DeriveDevelopmentNexusKeyMaterial(securitySettings);
+                NexusAppSettings.AddNexusKey(new NexusKey(keyMaterial, ByteEncoding.Base64UrlEncoded) { Default = true });
+            }
+
+            NexusAppSettings.Validate();
         }
-
-        NexusAppSettings.Validate();
+        catch
+        {
+            NexusAppSettings.Dispose();
+            throw;
+        }
     }
 
     [JsonIgnore]

--- a/DRN.Framework.Utils/Settings/AppSettings.cs
+++ b/DRN.Framework.Utils/Settings/AppSettings.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Serialization;
 using DRN.Framework.SharedKernel.Enums;
@@ -46,7 +47,7 @@ public interface IAppSettings
 }
 
 [Singleton<IAppSettings>]
-public class AppSettings : IAppSettings
+public class AppSettings : IAppSettings, IDisposable
 {
     private const string LegacyNexusMacKeysSection = "NexusAppSettings:MacKeys";
     private const string NexusKeysSection = "NexusAppSettings:Keys";
@@ -130,6 +131,8 @@ public class AppSettings : IAppSettings
     public string ApplicationNameNormalized { get; }
     public string GetAppSpecificName(string name, string prefix = "_") => $"{prefix}{ApplicationNameNormalized}.{name}.{AppKey}";
 
+    public void Dispose() => NexusAppSettings.Dispose();
+
     public bool TryGetConnectionString(string name, out string connectionString)
     {
         connectionString = Configuration.GetConnectionString(name)!;
@@ -184,11 +187,20 @@ public class AppSettings : IAppSettings
 
     private static string DeriveDevelopmentNexusKeyMaterial(AppSecuritySettings securitySettings)
     {
-        var keyMaterial = Blake3KeyDerivation.Derive32ByteKey(
-            Encoding.UTF8.GetBytes($"{securitySettings.AppHashKey}:{securitySettings.AppEncryptionKey}:{securitySettings.AppKey}"),
-            DevelopmentNexusKeyMaterialContext);
+        var developmentKeyMaterialSeed = Encoding.UTF8.GetBytes($"{securitySettings.AppHashKey}:{securitySettings.AppEncryptionKey}:{securitySettings.AppKey}");
 
-        return keyMaterial.Encode(ByteEncoding.Base64UrlEncoded);
+        try
+        {
+            using var keyMaterial = Blake3KeyDerivation.Derive32ByteKey(
+                developmentKeyMaterialSeed,
+                DevelopmentNexusKeyMaterialContext);
+
+            return keyMaterial.Span.Encode(ByteEncoding.Base64UrlEncoded);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(developmentKeyMaterialSeed);
+        }
     }
 
     private IConfiguration GetSectionOrRoot(string key) => string.IsNullOrEmpty(key)

--- a/DRN.Framework.Utils/Settings/NexusAppSettings.cs
+++ b/DRN.Framework.Utils/Settings/NexusAppSettings.cs
@@ -106,18 +106,29 @@ public class NexusKey : IDisposable
         Format = format;
 
         var decodedKeyMaterial = DecodeKey(keyMaterial, format);
+        SecretKey32? derivedMacKey = null;
+        SecretKey32? derivedEncryptionKey = null;
         try
         {
-            MacKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, MacKeyDerivationContext);
-            EncryptionKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, EncryptionKeyDerivationContext);
+            derivedMacKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, MacKeyDerivationContext);
+            derivedEncryptionKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, EncryptionKeyDerivationContext);
+
+            if (derivedMacKey.Length != RequiredKeyByteLength || derivedEncryptionKey.Length != RequiredKeyByteLength)
+                throw ExceptionFor.Configuration($"{nameof(NexusKey)} must resolve to exactly 32-byte MAC and encryption keys");
+
+            MacKey = derivedMacKey;
+            EncryptionKey = derivedEncryptionKey;
+        }
+        catch
+        {
+            derivedMacKey?.Dispose();
+            derivedEncryptionKey?.Dispose();
+            throw;
         }
         finally
         {
             CryptographicOperations.ZeroMemory(decodedKeyMaterial);
         }
-
-        if (!IsValid)
-            throw ExceptionFor.Configuration($"{nameof(NexusKey)} must resolve to exactly 32-byte MAC and encryption keys");
     }
 
 
@@ -145,36 +156,46 @@ public class NexusKey : IDisposable
         if (string.IsNullOrEmpty(key))
             throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must not be empty");
 
-        byte[] keyBytes;
+        byte[]? keyBytes = null;
         try
         {
-            keyBytes = format switch
+            try
             {
-                ByteEncoding.Utf8 => DecodeUtf8(key),
-                ByteEncoding.Hex => Convert.FromHexString(key),
-                ByteEncoding.Base64 => Convert.FromBase64String(key),
-                ByteEncoding.Base64UrlEncoded => key.Decode(ByteEncoding.Base64UrlEncoded).ToArray(),
-                _ => throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(Format)} is not supported")
-            };
-        }
-        catch (EncoderFallbackException exception)
-        {
-            throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must be valid {format} and resolve to exactly 32 bytes", exception);
-        }
-        catch (FormatException exception)
-        {
-            throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must be valid {format} and resolve to exactly 32 bytes", exception);
-        }
-        catch (ArgumentException exception) when (format is not ByteEncoding.Utf8)
-        {
-            throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must be valid {format} and resolve to exactly 32 bytes", exception);
-        }
+                keyBytes = format switch
+                {
+                    ByteEncoding.Utf8 => DecodeUtf8(key),
+                    ByteEncoding.Hex => Convert.FromHexString(key),
+                    ByteEncoding.Base64 => Convert.FromBase64String(key),
+                    ByteEncoding.Base64UrlEncoded => key.Decode(ByteEncoding.Base64UrlEncoded).ToArray(),
+                    _ => throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(Format)} is not supported")
+                };
+            }
+            catch (EncoderFallbackException exception)
+            {
+                throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must be valid {format} and resolve to exactly 32 bytes", exception);
+            }
+            catch (FormatException exception)
+            {
+                throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must be valid {format} and resolve to exactly 32 bytes", exception);
+            }
+            catch (ArgumentException exception) when (format is not ByteEncoding.Utf8)
+            {
+                throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must be valid {format} and resolve to exactly 32 bytes", exception);
+            }
 
-        if (keyBytes.Length != RequiredKeyByteLength)
-            throw ExceptionFor.Configuration(
-                $"{nameof(NexusKey)}.{nameof(KeyMaterial)} with format {format} must resolve to exactly 32 bytes; resolved length: {keyBytes.Length}");
+            if (keyBytes.Length != RequiredKeyByteLength)
+                throw ExceptionFor.Configuration(
+                    $"{nameof(NexusKey)}.{nameof(KeyMaterial)} with format {format} must resolve to exactly 32 bytes; resolved length: {keyBytes.Length}");
 
-        return keyBytes;
+            var result = keyBytes;
+            keyBytes = null;
+            return result;
+        }
+        finally
+        {
+            if (keyBytes is not null)
+                CryptographicOperations.ZeroMemory(keyBytes);
+        }
     }
 
     private static byte[] DecodeUtf8(string key)

--- a/DRN.Framework.Utils/Settings/NexusAppSettings.cs
+++ b/DRN.Framework.Utils/Settings/NexusAppSettings.cs
@@ -1,5 +1,7 @@
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Serialization;
+using DRN.Framework.Utils.Data.Encryption;
 using DRN.Framework.Utils.Data.Encodings;
 using DRN.Framework.Utils.Data.Hashing;
 using DRN.Framework.Utils.Data.Validation;
@@ -9,7 +11,7 @@ namespace DRN.Framework.Utils.Settings;
 /// <summary>
 /// In production values will be obtained from nexus as a remote configuration source
 /// </summary>
-public class NexusAppSettings
+public class NexusAppSettings : IDisposable
 {
     private IReadOnlyList<NexusKey> _keys = [];
 
@@ -73,6 +75,12 @@ public class NexusAppSettings
             if (Keys[index] is null)
                 throw ExceptionFor.Configuration($"{nameof(NexusAppSettings)}.{nameof(Keys)}[{index}] must not be null");
     }
+
+    public void Dispose()
+    {
+        foreach (var key in Keys)
+            key?.Dispose();
+    }
 }
 
 /// <summary>
@@ -82,7 +90,7 @@ public class NexusAppSettings
 /// Key derivation uses BLAKE3 context-string key derivation mode. See:
 /// <see href="https://docs.rs/blake3/latest/blake3/fn.derive_key.html"/>
 /// </remarks>
-public class NexusKey
+public class NexusKey : IDisposable
 {
     private const int RequiredKeyByteLength = 32;
     private const string MacKeyDerivationContext =
@@ -98,8 +106,15 @@ public class NexusKey
         Format = format;
 
         var decodedKeyMaterial = DecodeKey(keyMaterial, format);
-        MacKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, MacKeyDerivationContext);
-        EncryptionKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, EncryptionKeyDerivationContext);
+        try
+        {
+            MacKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, MacKeyDerivationContext);
+            EncryptionKey = Blake3KeyDerivation.Derive32ByteKey(decodedKeyMaterial, EncryptionKeyDerivationContext);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(decodedKeyMaterial);
+        }
 
         if (!IsValid)
             throw ExceptionFor.Configuration($"{nameof(NexusKey)} must resolve to exactly 32-byte MAC and encryption keys");
@@ -111,15 +126,21 @@ public class NexusKey
     public bool Default { get; init; }
 
     [JsonIgnore]
-    public BinaryData MacKey { get; }
+    internal SecretKey32 MacKey { get; }
 
     [JsonIgnore]
-    public BinaryData EncryptionKey { get; }
+    internal SecretKey32 EncryptionKey { get; }
 
     [JsonIgnore]
     public bool IsValid => MacKey.Length == RequiredKeyByteLength && EncryptionKey.Length == RequiredKeyByteLength;
 
-    private static BinaryData DecodeKey(string key, ByteEncoding format)
+    public void Dispose()
+    {
+        MacKey.Dispose();
+        EncryptionKey.Dispose();
+    }
+
+    private static byte[] DecodeKey(string key, ByteEncoding format)
     {
         if (string.IsNullOrEmpty(key))
             throw ExceptionFor.Configuration($"{nameof(NexusKey)}.{nameof(KeyMaterial)} must not be empty");
@@ -153,7 +174,7 @@ public class NexusKey
             throw ExceptionFor.Configuration(
                 $"{nameof(NexusKey)}.{nameof(KeyMaterial)} with format {format} must resolve to exactly 32 bytes; resolved length: {keyBytes.Length}");
 
-        return BinaryData.FromBytes(keyBytes);
+        return keyBytes;
     }
 
     private static byte[] DecodeUtf8(string key)

--- a/DRN.Test.Unit/Tests/Framework/Utils/AppSettingsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/AppSettingsTests.cs
@@ -51,6 +51,18 @@ public class AppSettingsTests
     }
 
     [Fact]
+    public void AppSettings_Should_Dispose_NexusAppSettings_Key_Material()
+    {
+        var settings = (AppSettings)AppSettings.Development(GetCustomSettings(56, 21));
+        var defaultNexusKey = settings.NexusAppSettings.GetDefaultKey();
+
+        settings.Dispose();
+
+        var action = () => { _ = defaultNexusKey.MacKey.Bytes; };
+        action.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
     public void AppSettings_Should_Reject_Legacy_MacKeys_Configuration_Before_Development_Key_Generation()
     {
         var configuration = new ConfigurationManager()

--- a/DRN.Test.Unit/Tests/Framework/Utils/Ids/IetfTestVectorGeneratorTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Ids/IetfTestVectorGeneratorTests.cs
@@ -111,8 +111,8 @@ public class IetfTestVectorGeneratorTests(ITestOutputHelper output)
         var entityIdUtils = context.GetRequiredService<ISourceKnownEntityIdUtils>();
 
         // --- A.1: Test Key Material ---
-        var macKeyBinary = nexusKey.MacKey;
-        var aesKeyBinary = nexusKey.EncryptionKey;
+        var macKey = nexusKey.MacKey;
+        var aesKey = nexusKey.EncryptionKey;
         var epochText = EpochTimeUtils.DefaultEpoch
             .ToUniversalTime()
             .ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
@@ -120,9 +120,9 @@ public class IetfTestVectorGeneratorTests(ITestOutputHelper output)
         // Assert key-material derivation matches draft-skid-00.md Appendix A.1
         nexusKey.Format.Should()
             .Be(ByteEncoding.Hex, "Appendix A.1 defines the canonical key material as hexadecimal octets");
-        Convert.ToHexString(macKeyBinary.ToArray()).Should()
+        Convert.ToHexString(macKey.Bytes).Should()
             .Be(TestMacKeyHex, "MAC key hex must match the Appendix A.1 derived MAC key");
-        Convert.ToHexString(aesKeyBinary.ToArray()).Should()
+        Convert.ToHexString(aesKey.Bytes).Should()
             .Be(TestAesKeyHex, "AES key hex must match the Appendix A.1 AES key derived from key material with BLAKE3 derive-key mode");
         epochText.Should()
             .Be("2025-01-01T00:00:00Z", "default epoch must match Appendix A.1");
@@ -130,8 +130,8 @@ public class IetfTestVectorGeneratorTests(ITestOutputHelper output)
         output.WriteLine($"""
             === A.1. Test Key Material ===
 
-            MAC Key (32 bytes, hex):   {Convert.ToHexString(macKeyBinary.ToArray())}
-            AES Key (32 bytes, hex):   {Convert.ToHexString(aesKeyBinary.ToArray())}
+            MAC Key (32 bytes, hex):   {Convert.ToHexString(macKey.Bytes)}
+            AES Key (32 bytes, hex):   {Convert.ToHexString(aesKey.Bytes)}
             Epoch:                     {epochText}
 
             """);

--- a/DRN.Test.Unit/Tests/Framework/Utils/Ids/SourceKnownEntityIdUtilsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Ids/SourceKnownEntityIdUtilsTests.cs
@@ -270,7 +270,7 @@ public class SourceKnownEntityIdUtilsTests
         // Decrypt the secure SKEID to access plaintext
         var cipherBytes = secureId.EntityId.ToByteArray(bigEndian: true);
         var aesKey = context.GetRequiredService<IAppSettings>()
-            .NexusAppSettings.GetDefaultKey().EncryptionKey.ToArray();
+            .NexusAppSettings.GetDefaultKey().EncryptionKey.Bytes;
 
         using var aes = Aes.Create();
         aes.Mode = CipherMode.ECB;

--- a/DRN.Test.Unit/Tests/Framework/Utils/Settings/NexusKeyTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Utils/Settings/NexusKeyTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Blake3;
 using DRN.Framework.SharedKernel.Json;
+using DRN.Framework.Utils.Data.Encryption;
 using DRN.Framework.Utils.Data.Encodings;
 
 namespace DRN.Test.Unit.Tests.Framework.Utils.Settings;
@@ -23,9 +24,68 @@ public class NexusKeyTests
 
         nexusKey.Format.Should().Be(format);
         nexusKey.IsValid.Should().BeTrue();
-        nexusKey.MacKey.ToArray().Should().Equal(DeriveExpectedKey(decodedKeyMaterial, MacKeyDerivationContext));
-        nexusKey.EncryptionKey.ToArray().Should().Equal(DeriveExpectedKey(decodedKeyMaterial, EncryptionKeyDerivationContext));
-        nexusKey.MacKey.ToArray().Should().NotEqual(nexusKey.EncryptionKey.ToArray());
+        nexusKey.MacKey.Should().BeOfType<SecretKey32>();
+        nexusKey.EncryptionKey.Should().BeOfType<SecretKey32>();
+        nexusKey.MacKey.Bytes.Should().Equal(DeriveExpectedKey(decodedKeyMaterial, MacKeyDerivationContext));
+        nexusKey.EncryptionKey.Bytes.Should().Equal(DeriveExpectedKey(decodedKeyMaterial, EncryptionKeyDerivationContext));
+        nexusKey.MacKey.Bytes.Should().NotEqual(nexusKey.EncryptionKey.Bytes);
+    }
+
+    [Fact]
+    public void SecretKey32_Should_Copy_Key_Material_And_Reject_Wrong_Lengths()
+    {
+        var source = SequentialKeyBytes.ToArray();
+        var key = new SecretKey32(source);
+        source[0] = byte.MaxValue;
+
+        key.Length.Should().Be(32);
+        key.Span.ToArray().Should().Equal(SequentialKeyBytes);
+        key.Memory.ToArray().Should().Equal(SequentialKeyBytes);
+        key.Bytes.Should().Equal(SequentialKeyBytes);
+
+        var action = () => { _ = new SecretKey32(new byte[31]); };
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SecretKey32_Should_Clear_And_Reject_Access_After_Dispose()
+    {
+        var key = new SecretKey32(SequentialKeyBytes);
+
+        key.Dispose();
+        var action = () => { _ = key.Bytes; };
+
+        action.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void NexusKey_Should_Dispose_Runtime_Key_Material()
+    {
+        var nexusKey = new NexusKey(Utf8Key, ByteEncoding.Utf8);
+        var macKey = nexusKey.MacKey;
+        var encryptionKey = nexusKey.EncryptionKey;
+
+        nexusKey.Dispose();
+
+        var macAction = () => { _ = macKey.Bytes; };
+        var encryptionAction = () => { _ = encryptionKey.Bytes; };
+        macAction.Should().Throw<ObjectDisposedException>();
+        encryptionAction.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void NexusAppSettings_Should_Dispose_Configured_Keys()
+    {
+        var firstKey = new NexusKey(Utf8Key, ByteEncoding.Utf8) { Default = true };
+        var secondKey = new NexusKey(SequentialKeyBytes.Encode(ByteEncoding.Hex), ByteEncoding.Hex);
+        var settings = new NexusAppSettings { Keys = [firstKey, secondKey] };
+
+        settings.Dispose();
+
+        var firstAction = () => { _ = firstKey.MacKey.Bytes; };
+        var secondAction = () => { _ = secondKey.EncryptionKey.Bytes; };
+        firstAction.Should().Throw<ObjectDisposedException>();
+        secondAction.Should().Throw<ObjectDisposedException>();
     }
 
     [Fact]
@@ -46,9 +106,9 @@ public class NexusKeyTests
         {
             key.MacKey.Length.Should().Be(32);
             key.EncryptionKey.Length.Should().Be(32);
-            key.MacKey.ToArray().Should().Equal(expectedMacKeyBytes);
-            key.EncryptionKey.ToArray().Should().Equal(expectedEncryptionKeyBytes);
-            key.MacKey.ToArray().Should().NotEqual(key.EncryptionKey.ToArray());
+            key.MacKey.Bytes.Should().Equal(expectedMacKeyBytes);
+            key.EncryptionKey.Bytes.Should().Equal(expectedEncryptionKeyBytes);
+            key.MacKey.Bytes.Should().NotEqual(key.EncryptionKey.Bytes);
         }
     }
 
@@ -97,7 +157,7 @@ public class NexusKeyTests
         roundTripped.KeyMaterial.Should().Be(key);
         roundTripped.Format.Should().Be(ByteEncoding.Base64UrlEncoded);
         roundTripped.Default.Should().BeTrue();
-        roundTripped.MacKey.ToArray().Should().Equal(DeriveExpectedKey(SequentialKeyBytes, MacKeyDerivationContext));
+        roundTripped.MacKey.Bytes.Should().Equal(DeriveExpectedKey(SequentialKeyBytes, MacKeyDerivationContext));
     }
 
     [Fact]
@@ -108,7 +168,7 @@ public class NexusKeyTests
 
         Encoding.UTF8.GetByteCount(key).Should().Be(32);
         key.Length.Should().NotBe(32);
-        nexusKey.MacKey.ToArray().Should().Equal(DeriveExpectedKey(Encoding.UTF8.GetBytes(key), MacKeyDerivationContext));
+        nexusKey.MacKey.Bytes.Should().Equal(DeriveExpectedKey(Encoding.UTF8.GetBytes(key), MacKeyDerivationContext));
     }
 
     [Fact]
@@ -131,7 +191,7 @@ public class NexusKeyTests
         settings.Should().NotBeNull();
         settings.Keys.Should().ContainSingle();
         settings.Keys[0].Format.Should().Be(ByteEncoding.Hex);
-        settings.Keys[0].MacKey.ToArray().Should().Equal(DeriveExpectedKey(SequentialKeyBytes, MacKeyDerivationContext));
+        settings.Keys[0].MacKey.Bytes.Should().Equal(DeriveExpectedKey(SequentialKeyBytes, MacKeyDerivationContext));
     }
 
     [Fact]
@@ -153,7 +213,7 @@ public class NexusKeyTests
         settings.Validate();
         settings.Keys.Should().ContainSingle();
         settings.Keys[0].Format.Should().Be(ByteEncoding.Base64UrlEncoded);
-        settings.Keys[0].MacKey.ToArray().Should().Equal(DeriveExpectedKey(SequentialKeyBytes, MacKeyDerivationContext));
+        settings.Keys[0].MacKey.Bytes.Should().Equal(DeriveExpectedKey(SequentialKeyBytes, MacKeyDerivationContext));
     }
 
     private static byte[] DeriveExpectedKey(ReadOnlySpan<byte> keyMaterial, string context)


### PR DESCRIPTION
Prevent sensitive cryptographic key material from lingering in memory by introducing the internal `SecretKey32` wrapper, which guarantees zeroing out the underlying byte array on disposal or finalization.

Propagate this secure container through `Blake3KeyDerivation`, `NexusKey`, `NexusSecret` (formerly `NexusKeyMaterial`), and `NexusKeyRing`, ensuring deterministic lifecycle management and disposal of all runtime keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encryption keys and related secrets by clearing sensitive data after use.
  * Added safer cleanup so configured and derived keys are disposed when settings are released.
  * Tightened key validation so invalid key input is rejected instead of being transformed or repaired.

* **New Features**
  * Introduced stronger in-memory secret handling for key material used by the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->