### PR TITLE
docs(framework): align app data and agent guidance

### DIFF
--- a/.agent/repository-profile.md
+++ b/.agent/repository-profile.md
@@ -60,7 +60,7 @@ When no narrower module is requested, `/documentation` targets:
 
 ## Commands
 
-Do not run build or test commands unless the user explicitly allows it.
+Do not run or plan build/test commands unless the user explicitly allows it.
 
 ```bash
 dotnet build DRN.slnx
@@ -93,6 +93,7 @@ Framework conventions and defaults live in framework-scoped DRN skills, especial
 |---|---|---|
 | Configuration source order | [ConfigurationExtensions.cs](../DRN.Framework.Hosting/Extensions/ConfigurationExtensions.cs) | Utils README, Hosting README, DRN framework skills |
 | Mounted settings paths | [MountedSettingsConventions.cs](../DRN.Framework.Utils/Settings/Conventions/MountedSettingsConventions.cs) | Utils README, Hosting README |
+| App data and temp paths | [AppConstants.cs](../DRN.Framework.SharedKernel/AppConstants.cs), [AppData.cs](../DRN.Framework.Utils/Data/App/AppData.cs), [DrnAppDataSettings.cs](../DRN.Framework.Utils/Settings/DrnAppDataSettings.cs) | SharedKernel README, Utils README, DRN framework skills |
 | Development settings defaults | [DrnDevelopmentSettings.cs](../DRN.Framework.Utils/Settings/DrnDevelopmentSettings.cs) | EntityFramework README, Testing README |
 | Test settings convention | [SettingsProvider.cs](../DRN.Framework.Testing/Providers/SettingsProvider.cs) | Testing README, testing skills |
 | Vite manifest discovery and publish support | [ViteManifest.cs](../DRN.Framework.Hosting/Utils/Vite/ViteManifest.cs), [DRN.Framework.Hosting.targets](../DRN.Framework.Hosting/buildTransitive/DRN.Framework.Hosting.targets) | Hosting README, frontend Vite skill, DRN hosting skill |
@@ -107,5 +108,7 @@ When source code changes a shared framework fact:
 4. Update framework-scoped DRN skills used for that package.
 5. Search changed terms, renamed keys, changed defaults, and removed examples across package docs, framework skills, `AGENTS.md`, and this profile.
 6. Run `git diff --check`.
+
+Documentation agents must classify public impact first. Skip private/internal-only checks unless needed to prove public behavior or docs accuracy.
 
 Release notes are not required for internal-only refactors, tests, comments, agent-only docs, dependency-only updates with no consumer-visible impact, or shared-version release alignment for packages with no package-specific changes. Dependency/runtime/container changes require release notes when they are breaking, security-relevant, consumer-visible, or alter published package artifacts. During release preparation, if no package-specific change exists before release, add one concise version-alignment disclaimer only when package metadata would otherwise be empty. Outside release preparation, leave unchanged package `RELEASE-NOTES.md` files untouched and report release notes as not required; the standard prefix covers consistency-only version increments.

--- a/.agent/skills/basic-agentic-development/SKILL.md
+++ b/.agent/skills/basic-agentic-development/SKILL.md
@@ -52,6 +52,7 @@ Context is a **finite resource**. Every token consumed reduces remaining capacit
 - Identify affected files and dependencies
 - Consider security implications (Priority Stack)
 - For significant changes: write plan, seek approval
+- Omit build/test/run steps from plans unless explicitly allowed.
 
 ### 3. Execution
 

--- a/.agent/skills/basic-agentic-development/SKILL.md
+++ b/.agent/skills/basic-agentic-development/SKILL.md
@@ -52,7 +52,7 @@ Context is a **finite resource**. Every token consumed reduces remaining capacit
 - Identify affected files and dependencies
 - Consider security implications (Priority Stack)
 - For significant changes: write plan, seek approval
-- Omit build/test/run steps from plans unless explicitly allowed.
+- Omit restore/build/run/test/benchmark/load-test steps from plans unless explicitly allowed.
 
 ### 3. Execution
 

--- a/.agent/skills/basic-documentation/SKILL.md
+++ b/.agent/skills/basic-documentation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: basic-documentation
 description: "Documentation standards - README structure, ROADMAP patterns, skill documentation format (YAML frontmatter), markdown conventions, security documentation, API docs, and best practices. Guidelines for creating and maintaining all project documentation. Keywords: documentation, readme, roadmap, markdown, documentation-standards, yaml-frontmatter, technical-writing, api-documentation, changelog"
-last-updated: 2026-06-14
+last-updated: 2026-07-07
 difficulty: basic
 tokens: ~1K
 ---
@@ -57,7 +57,9 @@ Update release notes when a change affects a published module's consumers or pac
 - Dependency, runtime, container, or build-output changes only when they are breaking, security-relevant, consumer-visible, or alter published package artifacts.
 - Published docs that are shipped as package metadata, such as package READMEs or release notes.
 
-Do not add release-note entries for internal-only refactors, tests, comments, agent-only docs, or routine dependency-only updates with no consumer-visible impact unless the repository profile declares a stricter rule.
+Do not add release-note entries for internal-only refactors, tests, comments, private/internal-only checks, agent-only docs, or routine dependency-only updates unless the repository profile declares a stricter rule.
+
+Skip private/internal-only checks unless needed to prove public behavior or docs accuracy.
 
 For version-aligned releases, do not add artificial version blocks to unchanged packages unless the repository profile explicitly requires them; record release notes as not required.
 

--- a/.agent/skills/drn-buildwww-vite/SKILL.md
+++ b/.agent/skills/drn-buildwww-vite/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drn-buildwww-vite
 description: "DRN buildwww Vite build system - multi-build configuration, TypeScript aliases, wwwroot output, appPreload/appPostload, and Vite manifest discovery. Keywords: drn, buildwww, vite, typescript, bundling, asset-compilation, npm, javascript, css, scss, build-pipeline, entry-points, manifest"
-last-updated: 2026-06-23
+last-updated: 2026-07-07
 difficulty: intermediate
 tokens: ~2K
 ---
@@ -78,7 +78,7 @@ const builds = {
         }
     },
     htmx: {
-        plugins: [stripHtmxEval(), iifeWrap()],
+        plugins: [iifeWrap(), stripHtmxEval()],
         build: {
             outDir: 'wwwroot/lib/htmx',
             rolldownOptions: {
@@ -97,7 +97,8 @@ const builds = {
                     bootstrapBundle: resolve(__dirname, 'buildwww/lib/bootstrap/bootstrapBundle.js')
                 }
             }
-        }
+        },
+        plugins: [iifeWrap()]
     },
     react: {
         plugins: [react(), tailwindcss()],

--- a/.agent/skills/drn-sharedkernel/SKILL.md
+++ b/.agent/skills/drn-sharedkernel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drn-sharedkernel
-description: "DRN.Framework.SharedKernel - Foundational domain primitives (Entity, AggregateRoot, DomainEvent), exception hierarchy, repository contracts, pagination, and JSON conventions. Essential for domain modeling, entity design, and repository implementation. Keywords: entity, aggregate-root, domain-event, repository, pagination, exception, json, domain-modeling, source-known-id, entity-type"
-last-updated: 2026-06-12
+description: "DRN.Framework.SharedKernel - Foundational domain primitives, exception hierarchy, repository contracts, pagination, JSON conventions, app constants, and shared casing/path extensions. Keywords: entity, aggregate-root, domain-event, repository, pagination, exception, json, domain-modeling, source-known-id, entity-type, appconstants, path-extensions"
+last-updated: 2026-07-07
 difficulty: intermediate
 tokens: ~2.5K
 ---
@@ -16,6 +16,7 @@ tokens: ~2.5K
 - Using or extending DRN exceptions
 - Understanding repository contracts
 - Accessing JSON serialization conventions
+- Using shared casing or safe path extensions in lower-layer packages
 
 ---
 
@@ -246,9 +247,25 @@ All factories accept optional `category` parameter for sub-classification: `Exce
 
 ```csharp
 AppConstants.ProcessId;          AppConstants.AppInstanceId;
-AppConstants.EntryAssemblyName;  AppConstants.TempPath;  // Cleaned at startup
+AppConstants.EntryAssemblyName;  AppConstants.EntryAssemblyNameNormalized;
+AppConstants.EntryAssemblyFullName;
+AppConstants.LocalAppDataPath;   AppConstants.TempPath;
 AppConstants.LocalIpAddress;
 ```
+
+`TempPath` order: `DrnAppDataSettings__TempPath` -> `DrnAppDataSettings__DataPath/Temp` -> local app data `Temp`. `LocalAppDataPath` order: `DrnAppDataSettings__DataPath` -> app-specific local app data. `IAppData` creates/cleans directories and resolves safe child paths.
+
+## Shared Extensions
+
+```csharp
+using DRN.Framework.SharedKernel.Extensions;
+
+"OrderHistory".ToSnakeCase();    // order_history
+"sample hosted".ToPascalCase();  // SampleHosted
+"/data/app".GetPathWithinDirectory("exports", "orders.json");
+```
+
+`GetPathWithinDirectory()` rejects parent-directory and symbolic-link traversal. Use it for file-serving, manifests, uploads, and app-data child paths.
 
 ## Attributes
 
@@ -274,5 +291,6 @@ AppConstants.LocalIpAddress;
 ```csharp
 global using DRN.Framework.SharedKernel.Domain;
 global using DRN.Framework.SharedKernel;
+global using DRN.Framework.SharedKernel.Extensions;
 global using DRN.Framework.SharedKernel.Json;
 ```

--- a/.agent/skills/drn-utils/SKILL.md
+++ b/.agent/skills/drn-utils/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drn-utils
-description: "DRN.Framework.Utils - Attribute-based dependency injection ([Scoped<T>], [Singleton<T>], [Transient<T>], [HostedService], [Config]), IAppSettings configuration pattern, logging infrastructure, validators, extension methods, and core utilities. Foundational for service registration, configuration management, and cross-cutting concerns. Keywords: dependency-injection, di, service-registration, configuration, appsettings, logging, scoped-log, validators, attributes, scoped, singleton, transient, config, extensions, http-client"
-last-updated: 2026-07-01
+description: "DRN.Framework.Utils - Attribute-based dependency injection ([Scoped<T>], [Singleton<T>], [Transient<T>], [HostedService], [Config]), IAppSettings configuration, app data roots, logging, validators, extension methods, and core utilities. Keywords: dependency-injection, di, service-registration, configuration, appsettings, appdata, logging, scoped-log, validators, attributes, scoped, singleton, transient, config, extensions, http-client"
+last-updated: 2026-07-07
 difficulty: intermediate
 tokens: ~2.5K
 ---
@@ -134,6 +134,10 @@ When grouping options into nested objects, explicitly validate child objects bef
 
 `DrnAppFeatures.SeedKey` feeds `AppSecuritySettings`, which derives `AppHashKey`, `AppEncryptionKey`, `AppKey`, and `AppSeed` through BLAKE3 derive-key mode with distinct DRN Framework context strings. The hash and encryption keys stay Base64Url-encoded 32-byte values, `AppKey` stays an 8-character public discriminator, and `AppSeed` stays a signed 64-bit seed value.
 
+### App Data Roots
+
+`IAppData` exposes `Temp` and `Data`. Override roots before DRN config with `DrnAppDataSettings__TempPath` and `DrnAppDataSettings__DataPath`; data path backs temp as `<DataPath>/Temp` when temp path is unset. Use `GetPath(...)` for safe child paths.
+
 ### Nexus Keys
 
 `NexusAppSettings.Keys` must contain exactly one default `NexusKey`. Generation uses the default key; parsing tries the default key first and then the remaining configured keys for rotation fallback.
@@ -258,6 +262,7 @@ if (scope.Acquired) { /* critical section */ }
 | **Streams** | `ToBinaryDataAsync` | Safe consumption with `MaxSizeGuard` |
 | **Validation** | `ValidationExtensions` | DataAnnotations-based programmatic validation |
 | **Validators** | `JpegValidator`, `JpegValidationResult`, `JpegValidationErrorReason` | Structural, stream-based, size-bounded JPEG validation with typed error reasons |
+| **App data** | `IAppData`, `AppDataPathResult`, `DrnAppDataSettings` | Validated temp/data roots with traversal-safe child path resolution |
 | **Pagination** | `IPaginationUtils` | Cursor-based via `SourceKnownEntityId` |
 | **Cancellation** | `ICancellationUtils` | Merge tokens from multiple sources |
 | **Diagnostics** | `DevelopmentStatus` | Track pending DB model changes at startup |
@@ -303,9 +308,9 @@ services.ReplaceSingleton<IMyService, MyService>(replacement);
 services.GetAllAssignableTo<TService>();
 
 // String & Binary
-"hello world".ToStream();       "camelCase".ToPascalCase();
-"MyProp".ToSnakeCase();         "MyProp".ToCamelCase();
+"hello world".ToStream();
 int v = "123".Parse<int>();     bool ok = "abc".TryParse<int>(out _);
+// Casing/path helpers live in DRN.Framework.SharedKernel.Extensions.
 
 // Type & Assembly
 assembly.GetTypesAssignableTo<TInterface>();

--- a/.agent/skills/overview-drn-framework/SKILL.md
+++ b/.agent/skills/overview-drn-framework/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: overview-drn-framework
 description: "DRN.Framework architecture overview - Package hierarchy (SharedKernel → Utils → Testing/EntityFramework → Hosting), dependency relationships, core conventions, and framework philosophy. Start here for understanding the overall framework structure. Keywords: framework, architecture, overview, package-hierarchy, conventions, framework-philosophy, package-dependencies"
-last-updated: 2026-07-01
+last-updated: 2026-07-07
 difficulty: basic
 tokens: ~3K
 ---
@@ -211,6 +211,10 @@ The mounted root defaults to `/appconfig` and can be overridden by registering `
 | `Prototype` | `false` | Development-only prototype database recreation gate. |
 | `BreakForUserUnhandledException` | `false` | Developer diagnostics flag. |
 
+### Maintenance Reference: App Data Paths
+
+App data paths resolve before DRN configuration. `TempPath` order: `DrnAppDataSettings__TempPath` -> `DrnAppDataSettings__DataPath/Temp` -> local app data `Temp`. `LocalAppDataPath` order: `DrnAppDataSettings__DataPath` -> app-specific local app data. `IAppData` owns directory creation, temp cleanup, test temp preservation, and safe child paths.
+
 ### Maintenance Reference: Migration And Prototype Invariants
 
 Production:
@@ -293,7 +297,7 @@ Every `DRN.Framework.*` package packs `RELEASE-NOTES.md` into NuGet metadata thr
 
 Triggers include public API/contract changes, behavior/default changes, security or operational posture changes, observable bug fixes, data/migration behavior, package metadata changes other than version-only alignment, and dependency/runtime/container changes that are breaking, security-relevant, consumer-visible, or alter published artifacts.
 
-Non-triggers include internal-only refactors, tests, comments, agent-only docs, routine dependency-only updates with no consumer-visible effect, and shared-version release alignment for packages with no package-specific changes. During release preparation, if no package-specific change exists before release, one concise version-alignment disclaimer may be added so package metadata is not empty for the release. Outside release preparation, when no trigger applies, explicitly report release notes as not required and leave that package's `RELEASE-NOTES.md` unchanged; the invariant prefix already explains that versions may advance for consistency even when a package has no changes.
+Non-triggers include internal-only refactors, tests, comments, private/internal implementation checks with no consumer-visible effect, agent-only docs, routine dependency-only updates with no consumer-visible effect, and shared-version release alignment for packages with no package-specific changes. During release preparation, if no package-specific change exists before release, one concise version-alignment disclaimer may be added so package metadata is not empty for the release. Outside release preparation, when no trigger applies, explicitly report release notes as not required and leave that package's `RELEASE-NOTES.md` unchanged; the invariant prefix already explains that versions may advance for consistency even when a package has no changes.
 
 ### Maintenance Reference: Release Notes Format
 

--- a/.agent/workflows/documentation.md
+++ b/.agent/workflows/documentation.md
@@ -41,6 +41,8 @@ Inspect outline: <Module>/<manifest-file>
 
 Read profile source-map files, public API surface, and recent scoped changes.
 
+Skip private/internal-only checks unless needed to prove public behavior or docs accuracy. Record internal-only changes as no docs/release-note trigger.
+
 Use a `.agent/temp/DEVELOP-*.md` artifact only when explicitly supplied or uniquely tied to the module. Block writes if it is `stale: true`, `needs_review: true`, `approval_required: true`, or contains `[ASSUMPTION - unverified]`.
 
 ## 4. Scan Drift
@@ -106,7 +108,7 @@ Add or update a block only for:
 - Dependency, runtime, container, or build-output changes that are breaking, security-relevant, consumer-visible, or alter published package artifacts.
 - Published docs shipped as package metadata.
 
-Do not add entries for internal-only refactors, tests, comments, agent-only docs, routine dependency-only changes with no consumer-visible impact, or unchanged version-aligned packages unless the profile requires them.
+Do not add entries for internal-only refactors, tests, comments, private/internal-only checks, agent-only docs, routine dependency-only changes, or unchanged version-aligned packages unless the profile requires them.
 
 Use only changes since the last documented version. Omit empty subsections. Include breaking changes. Keep inferred changes in the plan until source evidence or explicit approval resolves them; do not publish assumption markers unless requested.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Use the profile first. If it is missing or silent, discover by convention:
 - Comment only to explain non-obvious intent.
 - Update docs and skills when code or convention changes would otherwise create drift.
 - Decide release-note impact before finishing source, packaging, or published-doc changes; record "not required" when no trigger applies.
+- Omit restore/build/run/test/benchmark steps from plans unless explicitly allowed; use static verification instead.
 - **No CAD Artifact Bypassing**: `/clarify`, `/answer`, and `/develop` must create or update workspace-local artifacts such as `CLARIFY-*.md` and `DEVELOP-*.md` in `.agent/temp/`. System plans must reference and link those documents.
 - Run `git diff --check` after documentation or code edits unless blocked.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Use the profile first. If it is missing or silent, discover by convention:
 - Comment only to explain non-obvious intent.
 - Update docs and skills when code or convention changes would otherwise create drift.
 - Decide release-note impact before finishing source, packaging, or published-doc changes; record "not required" when no trigger applies.
-- Omit restore/build/run/test/benchmark steps from plans unless explicitly allowed; use static verification instead.
+- Omit restore/build/run/test/benchmark/load-test steps from plans unless explicitly allowed; use static verification instead.
 - **No CAD Artifact Bypassing**: `/clarify`, `/answer`, and `/develop` must create or update workspace-local artifacts such as `CLARIFY-*.md` and `DEVELOP-*.md` in `.agent/temp/`. System plans must reference and link those documents.
 - Run `git diff --check` after documentation or code edits unless blocked.
 

--- a/DRN.Framework.SharedKernel/README.md
+++ b/DRN.Framework.SharedKernel/README.md
@@ -20,6 +20,7 @@
 - **Domain primitives** - `SourceKnownEntity`, `AggregateRoot`, `DomainEvent` for DDD patterns
 - **Type-safe exceptions** - `ExceptionFor.NotFound()`, `ExceptionFor.Validation()` map to HTTP status codes
 - **JSON conventions** - Global `System.Text.Json` defaults with camelCase, enums-as-strings
+- **Shared extensions** - Casing and safe path helpers for lower-layer packages
 - **Source Known IDs** - Internal `long` for DB performance, external `Guid` for API security
 
 ## Table of Contents
@@ -32,6 +33,7 @@
 - [Exceptions](#exceptions)
 - [JsonConventions](#jsonconventions)
 - [Attributes](#attributes)
+- [Shared Extensions](#shared-extensions)
 - [AppConstants](#appconstants)
 - [Global Usings](#global-usings)
 - [Related Packages](#related-packages)
@@ -518,6 +520,24 @@ Validates that a string meets secure key requirements (length, character classes
 
 ---
 
+## Shared Extensions
+
+SharedKernel owns low-level extensions needed without higher-layer dependencies.
+
+```csharp
+using DRN.Framework.SharedKernel.Extensions;
+
+var schema = "OrderHistory".ToSnakeCase();     // order_history
+var typeName = "sample hosted".ToPascalCase(); // SampleHosted
+
+var root = "/data/app";
+var file = root.GetPathWithinDirectory("exports", "orders.json");
+```
+
+`GetPathWithinDirectory()` rejects parent-directory and symbolic-link traversal. Use it for file-serving, manifest, upload, and app-data child paths.
+
+---
+
 ## AppConstants
 
 ```csharp
@@ -528,10 +548,18 @@ public static class AppConstants
     public static int ProcessId { get; } = Environment.ProcessId;
     public static Guid AppInstanceId { get; } = Guid.NewGuid();
     public static string EntryAssemblyName { get; } = Assembly.GetEntryAssembly()?.GetName().Name ?? "Entry Assembly Not Found";
-    public static string TempPath { get; } = GetTempPath(); //Cleans directory at every startup
+    public static string EntryAssemblyNameNormalized { get; } = EntryAssemblyName.ToPascalCase();
+    public static string EntryAssemblyFullName { get; } = Assembly.GetEntryAssembly()?.GetName().FullName ?? "Entry Assembly Not Found";
+    public static string LocalAppDataPath { get; } = GetAppSpecificLocalDataPath();
+    public static string TempPath { get; } = GetTempPath();
     public static string LocalIpAddress { get; } = GetLocalIpAddress();
+
+    public const string LocalAppDataPathEnvVariable = "DrnAppDataSettings__DataPath";
+    public const string TempPathEnvVariable = "DrnAppDataSettings__TempPath";
 }
 ```
+
+`TempPath` order: `DrnAppDataSettings__TempPath` -> `DrnAppDataSettings__DataPath/Temp` -> local app data `Temp`. `LocalAppDataPath` order: `DrnAppDataSettings__DataPath` -> app-specific local app data. `IAppData` owns directory creation and cleanup.
 
 ---
 
@@ -542,6 +570,7 @@ Suggested consumer usings for projects that work heavily with SharedKernel types
 ```csharp
 global using DRN.Framework.SharedKernel.Domain;
 global using DRN.Framework.SharedKernel;
+global using DRN.Framework.SharedKernel.Extensions;
 global using DRN.Framework.SharedKernel.Json;
 ```
 

--- a/DRN.Framework.SharedKernel/RELEASE-NOTES.md
+++ b/DRN.Framework.SharedKernel/RELEASE-NOTES.md
@@ -4,11 +4,15 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 ### Security
 
-*   **Secure TempPath Directory**: Updated `AppConstants.TempPath` to resolve to a subdirectory under the user-specific, non-publicly-writable local application data directory (with fallback to the user profile or environment temporary directory only if local application data is unavailable). This mitigates vulnerabilities related to predictable/shared temporary file directories (CWE-377/CWE-379).
+*   **Secure TempPath Directory**: `AppConstants.TempPath` now resolves from `DrnAppDataSettings__TempPath`, `DrnAppDataSettings__DataPath/Temp`, then local app data `Temp`, avoiding predictable shared temp roots (CWE-377/CWE-379).
+
+### New Features
+
+*   **Shared Extension Methods**: Moved casing and safe path helpers to `DRN.Framework.SharedKernel.Extensions`.
 
 ### Breaking Changes
 
-*   **NexusKey BLAKE3 Derivation**: `NexusKey` now derives both `MacKey` and `EncryptionKey` from decoded 32-byte key material through BLAKE3 derive-key mode with distinct DRN Framework context strings. This replaces the previous custom hash-chain derivation and changes generated secure IDs; existing IDs may require migration, regeneration, or an explicit compatibility strategy.
+*   **AppConstants TempPath Ownership**: `AppConstants.TempPath` resolves only the temp root. Use `IAppData` for directory creation, cleanup, and child paths.
 
 ## Version 0.9.5
 

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -18,6 +18,7 @@
 
 - **Attribute DI** — `[Scoped<T>]`, `[Singleton<T>]`, `[Transient<T>]` for zero-config service registration
 - **Configuration** — `IAppSettings` with typed access, `[Config("Section")]` bindings
+- **App data roots** — `IAppData` resolves temp/data paths with traversal-safe child paths
 - **Scoped Logging** — `IScopedLog` aggregates structured logs per request
 - **Scoped Cancellation** — Scoped `ICancellationUtils` for request lifecycle control
 - **Validators** — Reusable payload validators such as `JpegValidator`
@@ -308,6 +309,17 @@ Override the mount directory by registering `IMountedSettingsConventionsOverride
 | Mounted settings not loading | Wrong mount path | Verify files exist at `/appconfig/json-settings/` or override via `IMountedSettingsConventionsOverride` |
 | Environment variables not binding | Wrong naming format | Use `__` (double underscore) for nested keys: `MySection__MyKey` |
 
+### App Data Settings
+
+`DrnAppDataSettings` controls required temp/data roots. Overrides use process environment variables because roots resolve before DRN configuration.
+
+| Environment variable | Purpose |
+|---|---|
+| `DrnAppDataSettings__TempPath` | Overrides the temp root used by `AppConstants.TempPath` and `IAppData.Temp`. |
+| `DrnAppDataSettings__DataPath` | Overrides data root; backs temp as `<DataPath>/Temp` when temp path is unset. |
+
+Set `DrnAppDataSettings:RequireTemp` or `DrnAppDataSettings:RequireData` to fail startup when the resolved path is not valid.
+
 ### DrnAppFeatures
 
 Feature flags and runtime knobs bound from the `DrnAppFeatures` configuration section via `[Config]`.
@@ -515,6 +527,20 @@ if (ScopeContext.IsUserInRole("Admin")) { ... }
 ```
 
 ## Data Utilities
+
+### App Data Roots (`IAppData`)
+
+`IAppData` exposes validated temp/data roots. Normal startup recreates temp; DRN test contexts preserve sibling test data.
+
+```csharp
+public class ExportService(IAppData appData)
+{
+    public string GetExportPath(string fileName) =>
+        appData.Temp.GetPath("exports", fileName);
+}
+```
+
+Use `AppDataPathResult.GetPath(...)` for traversal-safe child paths.
 
 ### Encodings (`EncodingExtensions`)
 
@@ -812,13 +838,13 @@ Advanced DI container manipulation for testing and modularity.
 *   **Querying**: `sc.GetAllAssignableTo<TService>()` retrieves all descriptors matching a type.
 *   **Replacement**: `ReplaceScoped`, `ReplaceSingleton`, and `ReplaceInstance` for mocking/overriding dependencies in integration tests.
 
-### String, Path & Binary Extensions
+### String & Binary Extensions
 
-*   **Casing**: `ToSnakeCase`, `ToCamelCase`, and `ToPascalCase` for clean code-to-external system mapping.
 *   **Parsing**: `string.Parse<T>()` and `string.TryParse<T>(out result)` using the modern `IParsable<T>` interface.
-*   **Path**: `NormalizeDirectoryPath()` resolves a directory path to a full path and trims trailing separators without trimming filesystem roots. `IsPathWithinDirectory()` performs full-path containment checks.
 *   **Binary**: `ToStream()` and `ToByteArray()` shortcuts with UTF8 default.
 *   **FileSystem**: `GetLines()` for `IFileInfo` with efficient physical path reading.
+
+Casing and safe path helpers live in `DRN.Framework.SharedKernel.Extensions`.
 
 ### Type & Assembly Extensions
 
@@ -845,8 +871,8 @@ var implementations = typeof(IMyInterface).Assembly.CreateSubTypes<IMyInterface>
 // Modern Parsing
 int value = "123".Parse<int>();
 
-// Casing for APIs
-var key = "MyPropertyName".ToSnakeCase(); // my_property_name
+// Binary shortcuts
+using var body = "payload".ToStream();
 ```
 
 ---
@@ -855,6 +881,7 @@ var key = "MyPropertyName".ToSnakeCase(); // my_property_name
 
 ```csharp
 global using DRN.Framework.SharedKernel;
+global using DRN.Framework.SharedKernel.Extensions;
 global using DRN.Framework.Utils.DependencyInjection;
 ```
 

--- a/DRN.Framework.Utils/RELEASE-NOTES.md
+++ b/DRN.Framework.Utils/RELEASE-NOTES.md
@@ -8,10 +8,17 @@ Not every version includes changes, features or bug fixes. This project can incr
 *   **NexusKey BLAKE3 Derivation**: `NexusKey` now derives both `MacKey` and `EncryptionKey` from decoded 32-byte key material through BLAKE3 derive-key mode with distinct DRN Framework context strings. This replaces the previous custom hash-chain derivation and changes generated secure IDs; existing IDs may require migration, regeneration, or an explicit compatibility strategy.
 *   **Development Nexus Key Material Derivation**: When `Development` has no explicit default Nexus key, `AppSettings` now derives deterministic 32-byte Base64Url key material with BLAKE3 derive-key mode from `AppSecuritySettings` context-derived values instead of the previous custom hash-chain. Development-generated secure IDs may require migration, regeneration, or an explicit compatibility key.
 *   **Legacy Nexus Key Configuration**: `AppSettings` now rejects legacy `NexusAppSettings:MacKeys` configuration before Development key auto-generation, preventing old key material from being silently ignored. Migrate `MacKeys[*].Key` to `Keys[*].KeyMaterial` and move matching `Format` and `Default` values to `Keys[*].Format` and `Keys[*].Default`.
+*   **Casing And Path Extension Relocation**: Casing and safe path helpers moved from Utils to `DRN.Framework.SharedKernel.Extensions`.
+*   **Settings Classes Sealed**: `AppSettings`, `NexusAppSettings`, and `NexusKey` are now sealed.
+
+### New Features
+
+*   **App Data Roots**: Added `IAppData` and related types for validated temp/data roots, startup temp cleanup, and safe child paths.
 
 ### Bug Fixes
 
 *   **AppSettings Nexus Key Validation**: Configured `NexusAppSettings:Keys` entries are now validated before default-key inspection, so null key entries report the intended configuration error instead of a null-reference failure.
+*   **Settings Disposal Idempotency**: Settings now ignore repeated disposal and dispose owned key material once.
 
 ## Version 0.9.5
 


### PR DESCRIPTION
Keep SharedKernel/Utils docs, release notes, and DRN skills consistent with AppConstants path resolution, including the DataPath temp fallback.

Clarify agent planning and documentation guidance so gated execution requires explicit allowance and release notes stay tied to public impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation now highlights app data root handling, including configurable temp/data paths and safer child-path resolution.
  * Added clearer guidance for shared path and casing helpers in the framework docs.

* **Documentation**
  * Expanded README and release-note guidance with updated examples, fallback behavior, and usage notes.
  * Improved workflow instructions for when documentation updates are needed and what can be skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->