### PR TITLE
ci(docker): separate Hub tokens, add OCI annotations, and split Scout…

### DIFF
--- a/.github/actions/docker-promote/action.yml
+++ b/.github/actions/docker-promote/action.yml
@@ -53,6 +53,22 @@ runs:
         while IFS= read -r tag; do
           [[ -n "$tag" ]] || continue
           docker buildx imagetools create --tag "$tag" "$source_image"
+          promoted_digest=""
+          for attempt in 1 2 3; do
+            if promoted_digest="$(
+              docker buildx imagetools inspect "$tag" --format '{{json .Manifest}}' |
+                jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))'
+            )" && [[ "$promoted_digest" == "$IMAGE_DIGEST" ]]; then
+              break
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep 2
+            fi
+          done
+          if [[ "$promoted_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "Promoted Docker tag resolved to $promoted_digest instead of expected digest $IMAGE_DIGEST: $tag"
+            exit 1
+          fi
         done <<'TAGS'
         ${{ steps.metadata.outputs.tags }}
         TAGS

--- a/.github/actions/docker-release-metadata/action.yml
+++ b/.github/actions/docker-release-metadata/action.yml
@@ -20,6 +20,9 @@ outputs:
   labels:
     description: "Docker image labels derived from the release version and GitHub context."
     value: ${{ steps.meta.outputs.labels }}
+  annotations:
+    description: "Docker image annotations derived from the release version and GitHub context."
+    value: ${{ steps.meta.outputs.annotations }}
 runs:
   using: "composite"
   steps:
@@ -67,6 +70,8 @@ runs:
     - name: Extract Docker release metadata
       id: meta
       uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+      env:
+        DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       with:
         images: ${{ inputs.registry }}/${{ inputs.image-repository-prefix }}/${{ inputs.image-repository-name }}
         flavor: |

--- a/.github/actions/docker-stage-scan/action.yml
+++ b/.github/actions/docker-stage-scan/action.yml
@@ -38,24 +38,31 @@ runs:
     - name: Build and stage Docker image
       id: container-build-digest
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      env:
+        BUILDX_GIT_LABELS: full
       with:
         context: .
         file: ./${{ inputs.project-name }}/Dockerfile
         labels: ${{ steps.metadata.outputs.labels }}
+        annotations: ${{ steps.metadata.outputs.annotations }}
         build-args: |
           APP_VERSION=${{ inputs.version }}
         platforms: ${{ inputs.platforms }}
         tags: ${{ inputs.registry }}/${{ inputs.image-repository-prefix }}/${{ inputs.image-repository-name }}:staged-${{ inputs.version }}-run-${{ github.run_id }}-${{ github.run_attempt }}
         push: true
         sbom: true
-        provenance: true
+        provenance: mode=max
         cache-from: type=gha,scope=${{ inputs.image-repository-name }}
         cache-to: type=gha,mode=max,scope=${{ inputs.image-repository-name }},ignore-error=true
-    - name: Validate staged Docker image digest
+    - name: Verify staged Docker image digest
       id: validate-image-digest
       shell: bash
       env:
+        DOCKER_REGISTRY: ${{ inputs.registry }}
         IMAGE_DIGEST: ${{ steps.container-build-digest.outputs.digest }}
+        IMAGE_REPOSITORY_NAME: ${{ inputs.image-repository-name }}
+        IMAGE_REPOSITORY_PREFIX: ${{ inputs.image-repository-prefix }}
+        RELEASE_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
 
@@ -63,22 +70,62 @@ runs:
           echo "Expected staged Docker image digest to be a sha256 digest, got: $IMAGE_DIGEST"
           exit 1
         fi
-    - name: Docker Scout
-      id: docker-scout
+
+        staged_image="${DOCKER_REGISTRY}/${IMAGE_REPOSITORY_PREFIX}/${IMAGE_REPOSITORY_NAME}:staged-${RELEASE_VERSION}-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        resolved_digest=""
+        for attempt in 1 2 3; do
+          if resolved_digest="$(
+            docker buildx imagetools inspect "$staged_image" --format '{{json .Manifest}}' |
+              jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))'
+          )" && [[ "$resolved_digest" == "$IMAGE_DIGEST" ]]; then
+            break
+          fi
+          if [[ "$attempt" -lt 3 ]]; then
+            sleep 2
+          fi
+        done
+
+        if [[ "$resolved_digest" != "$IMAGE_DIGEST" ]]; then
+          echo "Staged Docker tag resolved to $resolved_digest instead of expected digest $IMAGE_DIGEST: $staged_image"
+          exit 1
+        fi
+    - name: Docker Scout (linux/amd64)
+      id: docker-scout-amd64
       if: ${{ steps.container-build-digest.outcome == 'success' && steps.validate-image-digest.outcome == 'success' }}
       uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
       with:
         command: cves
         image: registry://${{ inputs.registry }}/${{ inputs.image-repository-prefix }}/${{ inputs.image-repository-name }}@${{ steps.container-build-digest.outputs.digest }}
-        sarif-file: sarif.${{ inputs.image-repository-name }}.output.json
+        platform: linux/amd64
+        sarif-file: sarif.${{ inputs.image-repository-name }}.linux-amd64.output.json
         summary: true
         only-severities: critical,high,medium,low
         exit-code: true
         ignore-base: false
-    - name: Upload Docker Scout SARIF result
-      id: upload-container-sarif
-      if: ${{ always() && steps.docker-scout.outcome != 'skipped' && hashFiles(format('sarif.{0}.output.json', inputs.image-repository-name)) != '' }}
+    - name: Docker Scout (linux/arm64)
+      id: docker-scout-arm64
+      if: ${{ always() && steps.container-build-digest.outcome == 'success' && steps.validate-image-digest.outcome == 'success' }}
+      uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
+      with:
+        command: cves
+        image: registry://${{ inputs.registry }}/${{ inputs.image-repository-prefix }}/${{ inputs.image-repository-name }}@${{ steps.container-build-digest.outputs.digest }}
+        platform: linux/arm64
+        sarif-file: sarif.${{ inputs.image-repository-name }}.linux-arm64.output.json
+        summary: true
+        only-severities: critical,high,medium,low
+        exit-code: true
+        ignore-base: false
+    - name: Upload Docker Scout SARIF result (linux/amd64)
+      id: upload-container-sarif-amd64
+      if: ${{ always() && steps.docker-scout-amd64.outcome != 'skipped' && hashFiles(format('sarif.{0}.linux-amd64.output.json', inputs.image-repository-name)) != '' }}
       uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
-        sarif_file: sarif.${{ inputs.image-repository-name }}.output.json
-        category: docker-scout-${{ inputs.image-repository-name }}
+        sarif_file: sarif.${{ inputs.image-repository-name }}.linux-amd64.output.json
+        category: docker-scout-${{ inputs.image-repository-name }}-linux-amd64
+    - name: Upload Docker Scout SARIF result (linux/arm64)
+      id: upload-container-sarif-arm64
+      if: ${{ always() && steps.docker-scout-arm64.outcome != 'skipped' && hashFiles(format('sarif.{0}.linux-arm64.output.json', inputs.image-repository-name)) != '' }}
+      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      with:
+        sarif_file: sarif.${{ inputs.image-repository-name }}.linux-arm64.output.json
+        category: docker-scout-${{ inputs.image-repository-name }}-linux-arm64

--- a/.github/actions/docker-stage-scan/action.yml
+++ b/.github/actions/docker-stage-scan/action.yml
@@ -117,14 +117,14 @@ runs:
         ignore-base: false
     - name: Upload Docker Scout SARIF result (linux/amd64)
       id: upload-container-sarif-amd64
-      if: ${{ always() && steps.docker-scout-amd64.outcome != 'skipped' && hashFiles(format('sarif.{0}.linux-amd64.output.json', inputs.image-repository-name)) != '' }}
+      if: ${{ always() && steps.docker-scout-amd64.outcome != 'skipped' }}
       uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         sarif_file: sarif.${{ inputs.image-repository-name }}.linux-amd64.output.json
         category: docker-scout-${{ inputs.image-repository-name }}-linux-amd64
     - name: Upload Docker Scout SARIF result (linux/arm64)
       id: upload-container-sarif-arm64
-      if: ${{ always() && steps.docker-scout-arm64.outcome != 'skipped' && hashFiles(format('sarif.{0}.linux-arm64.output.json', inputs.image-repository-name)) != '' }}
+      if: ${{ always() && steps.docker-scout-arm64.outcome != 'skipped' }}
       uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         sarif_file: sarif.${{ inputs.image-repository-name }}.linux-arm64.output.json

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -77,15 +77,15 @@ jobs:
       # enable "Require code scanning results", add CodeQL, then choose thresholds.
       # https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/set-merge-protection
 
-      # DOCKER_PASSWORD must be a Docker Hub PAT with Read, Write, and Delete permissions.
-      # Staging and promotion require Read/Write; best-effort staged-tag cleanup requires Delete.
+      # Personal Docker Hub publishing uses separate least-privilege PATs because trusted OIDC publishing
+      # is unavailable for personal namespaces. DOCKER_PUBLISH_TOKEN requires Read/Write permissions.
       - name: Stage and scan Docker images
         id: docker-images
         uses: ./.github/actions/docker-stage-scan-all
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
+          password: ${{ secrets.DOCKER_PUBLISH_TOKEN }}
           image-repository-prefix: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
           version: ${{ steps.version.outputs.version }}
 
@@ -110,8 +110,8 @@ jobs:
         uses: ./.github/actions/docker-promote-all
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
+          password: ${{ secrets.DOCKER_PUBLISH_TOKEN }}
           image-repository-prefix: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
           version: ${{ steps.version.outputs.version }}
           sample-image-digest: ${{ steps.docker-images.outputs.sample-image-digest }}
@@ -121,7 +121,7 @@ jobs:
         if: ${{ always() && steps.version.outcome == 'success' && steps.docker-images.outcome != 'skipped' && env.DOCKER_REGISTRY == 'docker.io' }}
         uses: ./.github/actions/docker-cleanup-staged-all
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
+          password: ${{ secrets.DOCKER_CLEANUP_TOKEN }}
           image-repository-prefix: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
           version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,15 +76,15 @@ jobs:
       # enable "Require code scanning results", add CodeQL, then choose thresholds.
       # https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/set-merge-protection
 
-      # DOCKER_PASSWORD must be a Docker Hub PAT with Read, Write, and Delete permissions.
-      # Staging and promotion require Read/Write; best-effort staged-tag cleanup requires Delete.
+      # Personal Docker Hub publishing uses separate least-privilege PATs because trusted OIDC publishing
+      # is unavailable for personal namespaces. DOCKER_PUBLISH_TOKEN requires Read/Write permissions.
       - name: Stage and scan Docker images
         id: docker-images
         uses: ./.github/actions/docker-stage-scan-all
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
+          password: ${{ secrets.DOCKER_PUBLISH_TOKEN }}
           image-repository-prefix: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
           version: ${{ steps.version.outputs.version }}
 
@@ -109,8 +109,8 @@ jobs:
         uses: ./.github/actions/docker-promote-all
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
+          password: ${{ secrets.DOCKER_PUBLISH_TOKEN }}
           image-repository-prefix: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
           version: ${{ steps.version.outputs.version }}
           sample-image-digest: ${{ steps.docker-images.outputs.sample-image-digest }}
@@ -120,7 +120,7 @@ jobs:
         if: ${{ always() && steps.version.outcome == 'success' && steps.docker-images.outcome != 'skipped' && env.DOCKER_REGISTRY == 'docker.io' }}
         uses: ./.github/actions/docker-cleanup-staged-all
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
+          password: ${{ secrets.DOCKER_CLEANUP_TOKEN }}
           image-repository-prefix: ${{ env.DOCKER_IMAGE_REPOSITORY_PREFIX }}
           version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
… scanning per platform

- Replace unified Docker Hub PAT with least-privilege publish and cleanup tokens
- Configure OCI metadata annotations and max provenance for staged images
- Split Docker Scout CVE scans and SARIF uploads per platform (amd64/arm64)
- Add digest verification retry loops after image staging and tag promotion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image verification during staging and promotion, including retries and digest matching to prevent publishing incorrect images.
  * Added platform-specific container scans for Linux AMD64 and ARM64 images.

* **Improvements**
  * Added richer image metadata, annotations, Git labels, and provenance information.
  * Updated release authentication with separate publishing and cleanup credentials for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->