### PR TITLE
feat(Testing): add multi-app in-memory HTTP routing

### DIFF
--- a/.agent/skills/drn-testing/SKILL.md
+++ b/.agent/skills/drn-testing/SKILL.md
@@ -115,10 +115,10 @@ public async Task Endpoint_Should_Return_Data(DrnTestContext context)
 | `DrnTestContextUnit` | unit tests without containers or full app startup | `ServiceCollection`, `GetRequiredService<T>()`, `BuildConfigurationRoot()`, `GetData()`, `MethodContext.GetTempPath()`, `GetTempPath()`, `ValidateServicesAsync()` |
 | `DrnTestContext` | integration tests | all unit capabilities plus `ContainerContext`, `ApplicationContext`, `FlurlHttpTest` |
 | `ContainerContext` | real dependencies | `Postgres.ApplyMigrationsAsync()`, `Postgres.Isolated`, `RabbitMq`, `BindExternalDependenciesAsync()` |
-| `ApplicationContext` | API/E2E tests | `CreateClientAsync<TProgram>()`, `CreateApplicationAndBindDependenciesAsync<TProgram>()`, automatic debugger-gated logging through `Xunit.TestContext.Current.TestOutputHelper` |
+| `ApplicationContext` | API/E2E tests | `CreateClientAsync<T>()`, `CreateClientForServiceAsync<T>()`, `CreateApplicationAndBindDependenciesAsync<T>()`, `MapAddress<T>()`, in-memory routing via `ApplicationContextRouterHandler`, automatic debugger-gated logging through `Xunit.TestContext.Current.TestOutputHelper` |
 | `FlurlHttpTest` | outbound HTTP mocks | `ForCallsTo(...).RespondWithJson(...)`, `ShouldHaveCalled(...)` |
 
-`DrnTestContext` owns the bootstrap and migration providers it builds. `ApplicationContext` only borrows the active host provider for service resolution; its `WebApplicationFactory` remains responsible for stopping and disposing that host before the context-owned provider is reset. Sequential applications rebuild context-owned services from current configuration, and a factory whose shutdown fails remains available for disposal retry.
+`DrnTestContext` owns the bootstrap and migration providers it builds. `ApplicationContext` manages one active `WebApplicationFactory` per application type and routes outbound HTTP calls between hosted services in-memory via `ApplicationContextRouterHandler`. Re-creating an application instance disposes and updates that specific factory and route bindings. Sequential applications rebuild context-owned services from current configuration, and a factory whose shutdown fails remains available for disposal retry.
 
 ## Consolidation Rule
 

--- a/.agent/skills/drn-utils/SKILL.md
+++ b/.agent/skills/drn-utils/SKILL.md
@@ -196,6 +196,8 @@ public class NexusRequest(IInternalRequest request, IAppSettings settings) : INe
 }
 ```
 
+`InternalRequest` and `ExternalRequest` accept an optional `HttpMessageHandler?` via constructor dependency injection, enabling in-memory routing and test interception (such as `ApplicationContextRouterHandler`) without mutating global Flurl static state.
+
 Buffered converters capture `HttpStatus` and `Payload`, then dispose the response even if reading fails. Use `using` for streaming wrappers; disposal releases the response and any `IDisposable` payload.
 Converters are exposed as extension methods on `Task<IFlurlResponse>` and `IFlurlResponse`; `HttpResponse` only models the converted result and its ownership.
 

--- a/DRN.Framework.Hosting/DRN.Framework.Hosting.csproj
+++ b/DRN.Framework.Hosting/DRN.Framework.Hosting.csproj
@@ -73,7 +73,7 @@
 
     <ItemGroup>
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
-        <PackageReference Include="NLog.Targets.Network" Version="6.1.4" />
+        <PackageReference Include="NLog.Targets.Network" Version="6.1.5" />
         <PackageReference Include="NLog.Web.AspNetCore" Version="6.2.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     </ItemGroup>

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
@@ -83,6 +83,7 @@ public interface IDrnProgram
 //todo: add csp manager
 //todo: review page for and endpoint for
 //todo: unify reports - startup, middleware, StaticAssetWarm, endpoint list etc
+//todo: add support for minimal apis (MapMinimalEndpoints, HttpJsonOptions, DrnEndpointSource discovery)
 /// <summary>
 /// <li><a href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host">Generic host model</a></li>
 /// <li><a href="https://learn.microsoft.com/en-us/aspnet/core/migration/50-to-60">WebApplication - new hosting model</a></li>
@@ -697,6 +698,11 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
         application.UseSwaggerUI(DrnProgramSwaggerOptions.ConfigureSwaggerUIOptionsAction);
     }
 
+    //todo: evaluate and add native support for Minimal APIs in DrnProgramBase:
+    // - MapMinimalEndpoints(WebApplication application, IAppSettings appSettings) extension point
+    // - Configure HttpJsonOptions with JsonConventions.SetHtmlSafeWebJsonDefaults
+    // - Extend EndpointCollectionBase<TProgram> and DrnEndpointSource to discover and index RouteEndpoints with MethodInfo/Delegate metadata
+    // - Ensure MFA requirements and authorization policies seamlessly evaluate minimal endpoint metadata
     protected virtual void MapApplicationEndpoints(WebApplication application, IAppSettings appSettings)
     {
         application.MapControllers();

--- a/DRN.Framework.Hosting/Nexus/NexusClient.cs
+++ b/DRN.Framework.Hosting/Nexus/NexusClient.cs
@@ -1,6 +1,5 @@
 using DRN.Framework.Utils.DependencyInjection.Attributes;
 using DRN.Framework.Utils.Http;
-using DRN.Framework.Utils.Models;
 using DRN.Framework.Utils.Models.Sample;
 using Flurl.Http;
 
@@ -16,8 +15,8 @@ public interface INexusClient
 public class NexusClient(INexusRequest request) : INexusClient
 {
     public async Task<HttpResponse<string>> GetStatusAsync() =>
-        await request.For("status").GetAsync().ToStringAsync();
+        await request.For(NexusEndpoints.Status).GetAsync().ToStringAsync();
 
     public async Task<HttpResponse<WeatherForecast[]>> GetWeatherForecastAsync() =>
-        await request.For("WeatherForecast").GetAsync().FromJsonAsync<WeatherForecast[]>();
+        await request.For(NexusEndpoints.WeatherForecast).GetAsync().FromJsonAsync<WeatherForecast[]>();
 }

--- a/DRN.Framework.Hosting/Nexus/NexusEndpoints.cs
+++ b/DRN.Framework.Hosting/Nexus/NexusEndpoints.cs
@@ -1,0 +1,34 @@
+namespace DRN.Framework.Hosting.Nexus;
+
+public static class NexusEndpoints
+{
+    public const string Prefix = "Api";
+    public const string StatusController = "Status";
+    public const string WeatherForecastController = "WeatherForecast";
+    public const string UserController = "User";
+
+    public const string Status = $"{Prefix}/{StatusController}";
+    public const string WeatherForecast = $"{Prefix}/{WeatherForecastController}";
+    public const string User = $"{Prefix}/{UserController}";
+
+    public static class Identity
+    {
+        public const string Prefix = $"{User}";
+
+        public const string LoginController = "NexusIdentityLogin";
+        public const string RegisterController = "NexusIdentityRegister";
+        public const string PasswordController = "NexusIdentityPassword";
+        public const string ManagementController = "NexusIdentityManagement";
+
+        public const string Login = $"{Prefix}/{LoginController}/Login";
+        public const string Refresh = $"{Prefix}/{LoginController}/Refresh";
+        public const string Register = $"{Prefix}/{RegisterController}/Register";
+        public const string ConfirmEmail = $"{Prefix}/{RegisterController}/ConfirmEmail";
+        public const string ResendConfirmationEmail = $"{Prefix}/{RegisterController}/ResendConfirmationEmail";
+        public const string ForgotPassword = $"{Prefix}/{PasswordController}/Forgot";
+        public const string ResetPassword = $"{Prefix}/{PasswordController}/Reset";
+        public const string TwoFactorAuth = $"{Prefix}/{ManagementController}/TwoFactorAuth";
+        public const string GetInfo = $"{Prefix}/{ManagementController}/GetInfo";
+        public const string PostInfo = $"{Prefix}/{ManagementController}/PostInfo";
+    }
+}

--- a/DRN.Framework.Hosting/packages.lock.json
+++ b/DRN.Framework.Hosting/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "NLog.Targets.Network": {
         "type": "Direct",
-        "requested": "[6.1.4, )",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "requested": "[6.1.5, )",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }

--- a/DRN.Framework.SharedKernel.Analyzers/DRN.Framework.SharedKernel.Analyzers.csproj
+++ b/DRN.Framework.SharedKernel.Analyzers/DRN.Framework.SharedKernel.Analyzers.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/DRN.Framework.SharedKernel.Analyzers/packages.lock.json
+++ b/DRN.Framework.SharedKernel.Analyzers/packages.lock.json
@@ -10,20 +10,20 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.9.0, )",
+        "resolved": "5.9.0",
+        "contentHash": "7JGDA0UT1+h7k9ZcA3rF4eFC8+QPq1xyYaXxag4p8r/zzPurEJxvdi7aM+MRL/SfP7XADXpWF/pl/eUYXOq/ww==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17",
+          "Microsoft.CodeAnalysis.Common": "[5.9.0]"
         }
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.9.0",
+        "contentHash": "IYaIaUWdIx539AReKZOBEqTskFusZfCh/wFSPilDvCn5Say8MegLw2LONcSIcVy+v3Gzv53qYBspgvBGSErfbQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17"
         }
       }
     },

--- a/DRN.Framework.Testing/Contexts/ApplicationContext.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContext.cs
@@ -21,6 +21,11 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
     private readonly Dictionary<Type, IDisposable> _factories = [];
     private ServiceDescriptor[]? _initialServiceDescriptors;
 
+    /// <summary>
+    /// In-memory router handler that dispatches HTTP requests across hosted applications.
+    /// Owned and disposed by <see cref="ApplicationContext"/>. When creating custom <see cref="HttpClient"/>
+    /// instances wrapping this handler directly, specify <c>disposeHandler: false</c> to prevent premature router disposal.
+    /// </summary>
     public ApplicationContextRouterHandler RouterHandler { get; } = new();
 
     internal static ITestOutputHelper? ResolveOutputHelper(ITestOutputHelper? supplied = null, bool debuggerOnly = true)

--- a/DRN.Framework.Testing/Contexts/ApplicationContext.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContext.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using DRN.Framework.Utils.Settings;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -17,17 +18,17 @@ namespace DRN.Framework.Testing.Contexts;
 
 public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
 {
-    private IDisposable? _factory;
+    private readonly Dictionary<Type, IDisposable> _factories = [];
     private ServiceDescriptor[]? _initialServiceDescriptors;
 
-    private static ITestOutputHelper? ResolveOutputHelper(
-        ITestOutputHelper? supplied = null,
-        bool debuggerOnly = true)
+    public ApplicationContextRouterHandler RouterHandler { get; } = new();
+
+    internal static ITestOutputHelper? ResolveOutputHelper(ITestOutputHelper? supplied = null, bool debuggerOnly = true)
     {
         if (debuggerOnly && !Debugger.IsAttached)
             return null;
 
-        return supplied ?? Xunit.TestContext.Current.TestOutputHelper;
+        return supplied ?? TestContext.Current.TestOutputHelper;
     }
 
     public WebApplicationFactory<TEntryPoint> CreateApplication<TEntryPoint>(Action<IWebHostBuilder>? webHostConfigurator = null)
@@ -37,41 +38,68 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
         return CreateApplicationCore<TEntryPoint>(outputHelper, webHostConfigurator);
     }
 
-    private WebApplicationFactory<TEntryPoint> CreateApplicationCore<TEntryPoint>(
-        ITestOutputHelper? outputHelper,
-        Action<IWebHostBuilder>? webHostConfigurator = null)
+    public WebApplicationFactory<TEntryPoint> CreateApplication<TEntryPoint>(Action<IWebHostBuilder>? webHostConfigurator, params string[] additionalAddresses)
         where TEntryPoint : class
     {
-        Dispose();
+        var outputHelper = ResolveOutputHelper();
+        return CreateApplicationCore<TEntryPoint>(outputHelper, webHostConfigurator, additionalAddresses);
+    }
 
-        _initialServiceDescriptors = testContext.ServiceCollection.ToArray();
+    /// <summary>
+    /// Creates an application and registers custom service names or address aliases in the in-memory router.
+    /// </summary>
+    public WebApplicationFactory<TEntryPoint> CreateApplicationForService<TEntryPoint>(string serviceName, params string[] additionalServiceNames)
+        where TEntryPoint : class
+    {
+        string[] allAddresses = [serviceName, .. additionalServiceNames];
+        return CreateApplication<TEntryPoint>(webHostConfigurator: null, additionalAddresses: allAddresses);
+    }
+
+    internal WebApplicationFactory<TEntryPoint> CreateApplicationCore<TEntryPoint>(
+        ITestOutputHelper? outputHelper,
+        Action<IWebHostBuilder>? webHostConfigurator = null,
+        IEnumerable<string>? additionalAddresses = null)
+        where TEntryPoint : class
+    {
+        DisposeFactory(typeof(TEntryPoint));
+
+        _initialServiceDescriptors ??= testContext.ServiceCollection.ToArray();
         var initialServiceDescriptors = _initialServiceDescriptors;
-        //Add program services to drnTestContext
-        using (var tempApplicationFactory = new DrnWebApplicationFactory<TEntryPoint>(testContext, true, webHostBuilder =>
-        {
-            //only need service collection descriptors, so ValidateServicesAddedByAttributes should not fail test at this stage
-            var configuration = testContext.GetRequiredService<IConfiguration>();
-            webHostBuilder.UseConfiguration(configuration);
-            webHostBuilder.UseSetting(DrnDevelopmentSettings.GetKey(nameof(DrnDevelopmentSettings.SkipValidation)), "true");
-            webHostBuilder.UseSetting(DrnDevelopmentSettings.GetKey(nameof(DrnDevelopmentSettings.TemporaryApplication)), "true");
-            webHostBuilder.ConfigureLogging(logging => logging.ClearProviders());
 
-            webHostConfigurator?.Invoke(webHostBuilder);
-            webHostBuilder.ConfigureServices(services => testContext.ServiceCollection.Add(services));
-        }))
+        // Add program services to drnTestContext
+        using (var tempApplicationFactory = new DrnWebApplicationFactory<TEntryPoint>(testContext, true, webHostBuilder =>
+               {
+                   // only need service collection descriptors, so ValidateServicesAddedByAttributes should not fail test at this stage
+                   var configuration = testContext.BuildConfigurationRoot();
+                   webHostBuilder.UseConfiguration(configuration);
+                   webHostBuilder.UseSetting(DrnDevelopmentSettings.GetKey(nameof(DrnDevelopmentSettings.SkipValidation)), "true");
+                   webHostBuilder.UseSetting(DrnDevelopmentSettings.GetKey(nameof(DrnDevelopmentSettings.TemporaryApplication)), "true");
+                   webHostBuilder.ConfigureLogging(logging => logging.ClearProviders());
+
+                   webHostConfigurator?.Invoke(webHostBuilder);
+                   webHostBuilder.ConfigureServices(services => testContext.ServiceCollection.Add(services));
+               }))
         {
-            _ = tempApplicationFactory.Server; //To trigger webHostBuilder action
+            _ = tempApplicationFactory.Server; // To trigger webHostBuilder action
         }
 
-        //register action to pass test context configuration to web application.
-        //This will be triggered when TestServer or HttpClient requested until then further configurations can be added to test context configuration
+        // register action to pass test context configuration to web application.
+        // This will be triggered when TestServer or HttpClient requested until then further configurations can be added to test context configuration
         IConfiguration? factoryConfiguration = null;
         var factory = new DrnWebApplicationFactory<TEntryPoint>(testContext, false, webHostBuilder =>
         {
             // Derived factories replay this configurator after the active provider changes to the parent host.
-            var configuration = factoryConfiguration ??= testContext.GetRequiredService<IConfiguration>();
+            var configuration = factoryConfiguration ??= testContext.BuildConfigurationRoot();
             webHostBuilder.UseConfiguration(configuration);
-            webHostBuilder.ConfigureServices(services => services.Add(initialServiceDescriptors));
+            webHostBuilder.ConfigureServices(services =>
+            {
+                services.Add(initialServiceDescriptors);
+                services.AddSingleton<HttpMessageHandler>(_ => RouterHandler.CreateForwardingHandler());
+                services.ConfigureAll<Microsoft.Extensions.Http.HttpClientFactoryOptions>(options =>
+                {
+                    options.HttpMessageHandlerBuilderActions.Add(builder => { builder.PrimaryHandler = RouterHandler.CreateForwardingHandler(); });
+                });
+            });
 
             webHostBuilder.ConfigureLogging(logging =>
             {
@@ -110,10 +138,74 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
             });
         });
 
-        UseApplicationFactory(factory);
+        _factories[typeof(TEntryPoint)] = factory;
+
+        var extraAddresses = new List<string>(additionalAddresses ?? []);
+        var config = testContext.BuildConfigurationRoot();
+        DiscoverConfiguredAddresses(config, typeof(TEntryPoint), extraAddresses);
+
+        RouterHandler.Register(typeof(TEntryPoint), () => factory.Server.CreateHandler(), extraAddresses);
 
         return factory;
     }
+
+    internal void RegisterConfiguredAddresses(Type entryPointType, IConfiguration configuration)
+    {
+        var addresses = new List<string>();
+        DiscoverConfiguredAddresses(configuration, entryPointType, addresses);
+        foreach (var address in addresses)
+            RouterHandler.RegisterAddress(address, entryPointType);
+    }
+
+    private static void DiscoverConfiguredAddresses(IConfiguration configuration, Type entryPointType, List<string> addresses)
+    {
+        var typeName = entryPointType.Name;
+        var shortName = GetShortName(typeName);
+
+        var kestrelEndpoints = configuration.GetSection("Kestrel:Endpoints");
+        if (kestrelEndpoints.Exists())
+        {
+            foreach (var endpoint in kestrelEndpoints.GetChildren())
+            {
+                var url = endpoint["Url"];
+                if (!string.IsNullOrWhiteSpace(url))
+                    addresses.Add(url);
+            }
+        }
+
+        foreach (var kvp in configuration.AsEnumerable())
+        {
+            if (string.IsNullOrWhiteSpace(kvp.Value))
+                continue;
+
+            var key = kvp.Key;
+            var isAddressKey = key.EndsWith("Address", StringComparison.OrdinalIgnoreCase) ||
+                               key.EndsWith("Url", StringComparison.OrdinalIgnoreCase) ||
+                               key.EndsWith("Uri", StringComparison.OrdinalIgnoreCase);
+
+            if (!isAddressKey)
+                continue;
+
+            var matchesTypeName = key.Contains(typeName, StringComparison.OrdinalIgnoreCase);
+            var matchesShortName = !string.IsNullOrEmpty(shortName) && key.Contains(shortName, StringComparison.OrdinalIgnoreCase);
+
+            if (matchesTypeName || matchesShortName) addresses.Add(kvp.Value);
+        }
+    }
+
+    private static string GetShortName(string typeName) => ApplicationContextRouterHandler.GetShortName(typeName);
+
+    /// <summary>
+    /// Explicitly maps a hostname, port, or base URL to a registered application's in-memory <see cref="HttpMessageHandler"/>.
+    /// </summary>
+    public void MapAddress<TEntryPoint>(string address) where TEntryPoint : class =>
+        RouterHandler.RegisterAddress(address, typeof(TEntryPoint));
+
+    /// <summary>
+    /// Explicitly maps a hostname, port, or base URL to a specific <see cref="HttpMessageHandler"/>.
+    /// </summary>
+    public void MapAddress(string address, HttpMessageHandler handler) =>
+        RouterHandler.RegisterAddress(address, handler);
 
     /// <summary>
     /// Most used defaults and bindings for testing an api endpoint gathered together
@@ -130,10 +222,37 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
     }
 
     /// <summary>
+    /// Most used defaults and bindings for testing an api endpoint gathered together with custom address bindings.
+    /// </summary>
+    public async Task<WebApplicationFactory<TEntryPoint>> CreateApplicationAndBindDependenciesAsync<TEntryPoint>(
+        ITestOutputHelper? outputHelper,
+        params string[] additionalAddresses) where TEntryPoint : class
+    {
+        var resolvedOutputHelper = ResolveOutputHelper(outputHelper);
+        var application = CreateApplicationCore<TEntryPoint>(resolvedOutputHelper, additionalAddresses: additionalAddresses);
+        await testContext.ContainerContext.BindExternalDependenciesAsync();
+        application.Server.PreserveExecutionContext = true;
+
+        return application;
+    }
+
+    /// <summary>
+    /// Most used defaults and bindings for testing an api endpoint gathered together with custom service names.
+    /// </summary>
+    public async Task<WebApplicationFactory<TEntryPoint>> CreateApplicationAndBindDependenciesForServiceAsync<TEntryPoint>(
+        string serviceName,
+        params string[] additionalServiceNames) where TEntryPoint : class
+    {
+        string[] allAddresses = [serviceName, .. additionalServiceNames];
+        return await CreateApplicationAndBindDependenciesAsync<TEntryPoint>(outputHelper: null, additionalAddresses: allAddresses);
+    }
+
+    /// <summary>
     /// Most used defaults and bindings for testing an api endpoint gathered together
     /// </summary>
     /// <returns>HttpClient instead of FlurlClient to prevent flurl http test server collision</returns>
-    public async Task<HttpClient> CreateClientAsync<TEntryPoint>(ITestOutputHelper? outputHelper = null,
+    public async Task<HttpClient> CreateClientAsync<TEntryPoint>(
+        ITestOutputHelper? outputHelper = null,
         WebApplicationFactoryClientOptions? clientOptions = null) where TEntryPoint : class
     {
         clientOptions ??= new WebApplicationFactoryClientOptions();
@@ -145,33 +264,112 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
         return client;
     }
 
+    /// <summary>
+    /// Most used defaults and bindings for testing an api endpoint gathered together with custom address bindings.
+    /// </summary>
+    /// <returns>HttpClient instead of FlurlClient to prevent flurl http test server collision</returns>
+    public async Task<HttpClient> CreateClientAsync<TEntryPoint>(
+        ITestOutputHelper? outputHelper,
+        WebApplicationFactoryClientOptions? clientOptions,
+        params string[] additionalAddresses) where TEntryPoint : class
+    {
+        clientOptions ??= new WebApplicationFactoryClientOptions();
+        clientOptions.BaseAddress = new Uri(TestEnvironment.TestContextAddress);
+
+        var application = await CreateApplicationAndBindDependenciesAsync<TEntryPoint>(outputHelper, additionalAddresses);
+        var client = application.CreateClient(clientOptions);
+
+        return client;
+    }
+
+    /// <summary>
+    /// Most used defaults and bindings for testing an api endpoint gathered together with custom service names.
+    /// </summary>
+    public async Task<HttpClient> CreateClientForServiceAsync<TEntryPoint>(
+        string serviceName,
+        params string[] additionalServiceNames) where TEntryPoint : class
+    {
+        string[] allAddresses = [serviceName, .. additionalServiceNames];
+        return await CreateClientAsync<TEntryPoint>(outputHelper: null, clientOptions: null, additionalAddresses: allAddresses);
+    }
+
     public WebApplicationFactory<TEntryPoint>? GetCreatedApplication<TEntryPoint>() where TEntryPoint : class
-        => (WebApplicationFactory<TEntryPoint>?)_factory;
+        => _factories.TryGetValue(typeof(TEntryPoint), out var factory) ? (WebApplicationFactory<TEntryPoint>?)factory : null;
 
-    internal bool HasCreatedApplication => _factory != null;
+    public IReadOnlyCollection<IDisposable> GetCreatedApplications() => _factories.Values.ToArray();
 
-    internal void UseApplicationFactory(IDisposable factory) => _factory = factory;
+    internal bool HasCreatedApplication => _factories.Count > 0;
+
+    internal void UseApplicationFactory(IDisposable factory) => _factories[factory.GetType()] = factory;
+
+    private void DisposeFactory(Type type)
+    {
+        if (!_factories.Remove(type, out var factory))
+            return;
+
+        RouterHandler.Unregister(type);
+        try
+        {
+            factory.Dispose();
+        }
+        catch
+        {
+            _factories[type] = factory;
+            throw;
+        }
+    }
 
     public void Dispose()
     {
-        var factory = _factory;
+        var factories = _factories.ToArray();
+        _factories.Clear();
+        RouterHandler.Clear();
+        var exceptions = new List<Exception>();
+
+        foreach (var (type, factory) in factories)
+        {
+            try
+            {
+                factory.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _factories[type] = factory;
+                exceptions.Add(ex);
+            }
+        }
+
         try
         {
-            factory?.Dispose();
-            _factory = null;
-        }
-        finally
-        {
-            if (_initialServiceDescriptors != null)
+            if (_initialServiceDescriptors != null && _factories.Count == 0)
             {
                 testContext.ServiceCollection = new ServiceCollection { _initialServiceDescriptors };
                 _initialServiceDescriptors = null;
             }
+
             testContext.ClearApplicationServiceProvider();
         }
+        catch (Exception ex)
+        {
+            exceptions.Add(ex);
+        }
 
-        if (factory != null)
-            testContext.DisposeOwnedServiceProvider();
+        if (_factories.Count == 0 && factories.Length > 0)
+        {
+            try
+            {
+                testContext.DisposeOwnedServiceProvider();
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        }
+
+        if (exceptions.Count == 1)
+            ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+        if (exceptions.Count > 1)
+            throw new AggregateException("One or more errors occurred during ApplicationContext disposal.", exceptions);
     }
 }
 
@@ -207,8 +405,12 @@ public class DrnWebApplicationFactory<TEntryPoint> : WebApplicationFactory<TEntr
         try
         {
             var host = base.CreateHost(capturingBuilder);
-            if (!Temporary)
-                _context.UseApplicationServiceProvider(host.Services);
+            if (Temporary)
+                return new FailureSafeHost(host);
+
+            _context.UseApplicationServiceProvider(host.Services);
+            if (host.Services.GetService(typeof(IConfiguration)) is IConfiguration configuration)
+                _context.ApplicationContext.RegisterConfiguredAddresses(typeof(TEntryPoint), configuration);
 
             return new FailureSafeHost(host);
         }

--- a/DRN.Framework.Testing/Contexts/ApplicationContext.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContext.cs
@@ -31,14 +31,9 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
         return supplied ?? TestContext.Current.TestOutputHelper;
     }
 
-    public WebApplicationFactory<TEntryPoint> CreateApplication<TEntryPoint>(Action<IWebHostBuilder>? webHostConfigurator = null)
-        where TEntryPoint : class
-    {
-        var outputHelper = ResolveOutputHelper();
-        return CreateApplicationCore<TEntryPoint>(outputHelper, webHostConfigurator);
-    }
-
-    public WebApplicationFactory<TEntryPoint> CreateApplication<TEntryPoint>(Action<IWebHostBuilder>? webHostConfigurator, params string[] additionalAddresses)
+    public WebApplicationFactory<TEntryPoint> CreateApplication<TEntryPoint>(
+        Action<IWebHostBuilder>? webHostConfigurator = null,
+        params string[] additionalAddresses)
         where TEntryPoint : class
     {
         var outputHelper = ResolveOutputHelper();
@@ -231,24 +226,10 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
         RouterHandler.RegisterAddress(address, handler);
 
     /// <summary>
-    /// Most used defaults and bindings for testing an api endpoint gathered together
-    /// </summary>
-    public async Task<WebApplicationFactory<TEntryPoint>> CreateApplicationAndBindDependenciesAsync<TEntryPoint>(
-        ITestOutputHelper? outputHelper = null) where TEntryPoint : class
-    {
-        var resolvedOutputHelper = ResolveOutputHelper(outputHelper);
-        var application = CreateApplicationCore<TEntryPoint>(resolvedOutputHelper);
-        await testContext.ContainerContext.BindExternalDependenciesAsync();
-        application.Server.PreserveExecutionContext = true;
-
-        return application;
-    }
-
-    /// <summary>
     /// Most used defaults and bindings for testing an api endpoint gathered together with custom address bindings.
     /// </summary>
     public async Task<WebApplicationFactory<TEntryPoint>> CreateApplicationAndBindDependenciesAsync<TEntryPoint>(
-        ITestOutputHelper? outputHelper,
+        ITestOutputHelper? outputHelper = null,
         params string[] additionalAddresses) where TEntryPoint : class
     {
         var resolvedOutputHelper = ResolveOutputHelper(outputHelper);
@@ -271,29 +252,12 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
     }
 
     /// <summary>
-    /// Most used defaults and bindings for testing an api endpoint gathered together
-    /// </summary>
-    /// <returns>HttpClient instead of FlurlClient to prevent flurl http test server collision</returns>
-    public async Task<HttpClient> CreateClientAsync<TEntryPoint>(
-        ITestOutputHelper? outputHelper = null,
-        WebApplicationFactoryClientOptions? clientOptions = null) where TEntryPoint : class
-    {
-        clientOptions ??= new WebApplicationFactoryClientOptions();
-        clientOptions.BaseAddress = new Uri(TestEnvironment.TestContextAddress);
-
-        var application = await CreateApplicationAndBindDependenciesAsync<TEntryPoint>(outputHelper);
-        var client = application.CreateClient(clientOptions);
-
-        return client;
-    }
-
-    /// <summary>
     /// Most used defaults and bindings for testing an api endpoint gathered together with custom address bindings.
     /// </summary>
     /// <returns>HttpClient instead of FlurlClient to prevent flurl http test server collision</returns>
     public async Task<HttpClient> CreateClientAsync<TEntryPoint>(
-        ITestOutputHelper? outputHelper,
-        WebApplicationFactoryClientOptions? clientOptions,
+        ITestOutputHelper? outputHelper = null,
+        WebApplicationFactoryClientOptions? clientOptions = null,
         params string[] additionalAddresses) where TEntryPoint : class
     {
         clientOptions ??= new WebApplicationFactoryClientOptions();

--- a/DRN.Framework.Testing/Contexts/ApplicationContext.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContext.cs
@@ -157,6 +157,8 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
             RouterHandler.RegisterAddress(address, entryPointType);
     }
 
+    private static readonly string[] AddressSuffixes = ["Address", "Url", "Uri"];
+
     private static void DiscoverConfiguredAddresses(IConfiguration configuration, Type entryPointType, List<string> addresses)
     {
         var typeName = entryPointType.Name;
@@ -186,12 +188,33 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
             if (!isAddressKey)
                 continue;
 
-            var matchesTypeName = key.Contains(typeName, StringComparison.OrdinalIgnoreCase);
-            var matchesShortName = !string.IsNullOrEmpty(shortName) && key.Contains(shortName, StringComparison.OrdinalIgnoreCase);
-
-            if (matchesTypeName || matchesShortName) addresses.Add(kvp.Value);
+            var segments = key.Split(':');
+            if (segments.Any(segment => MatchesAddressSegment(segment, typeName, shortName)))
+                addresses.Add(kvp.Value);
         }
     }
+
+    private static bool MatchesAddressSegment(string segment, string typeName, string shortName)
+    {
+        if (IsExactMatch(segment, typeName, shortName))
+            return true;
+
+        foreach (var suffix in AddressSuffixes)
+        {
+            if (segment.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) && segment.Length > suffix.Length)
+            {
+                var prefix = segment[..^suffix.Length];
+                if (IsExactMatch(prefix, typeName, shortName))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsExactMatch(string value, string typeName, string shortName) =>
+        value.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
+        (!string.IsNullOrEmpty(shortName) && value.Equals(shortName, StringComparison.OrdinalIgnoreCase));
 
     private static string GetShortName(string typeName) => ApplicationContextRouterHandler.GetShortName(typeName);
 

--- a/DRN.Framework.Testing/Contexts/ApplicationContext.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContext.cs
@@ -281,13 +281,16 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
     }
 
     public WebApplicationFactory<TEntryPoint>? GetCreatedApplication<TEntryPoint>() where TEntryPoint : class
-        => _factories.TryGetValue(typeof(TEntryPoint), out var factory) ? (WebApplicationFactory<TEntryPoint>?)factory : null;
+        => _factories.TryGetValue(typeof(TEntryPoint), out var factory) && factory is WebApplicationFactory<TEntryPoint> application
+            ? application
+            : null;
 
     public IReadOnlyCollection<IDisposable> GetCreatedApplications() => _factories.Values.ToArray();
 
     internal bool HasCreatedApplication => _factories.Count > 0;
 
-    internal void UseApplicationFactory(IDisposable factory) => _factories[factory.GetType()] = factory;
+    internal void UseApplicationFactory<TEntryPoint>(IDisposable factory) where TEntryPoint : class
+        => _factories[typeof(TEntryPoint)] = factory;
 
     private void DisposeFactory(Type type)
     {

--- a/DRN.Framework.Testing/Contexts/ApplicationContext.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContext.cs
@@ -189,16 +189,31 @@ public sealed class ApplicationContext(DrnTestContext testContext) : IDisposable
                 continue;
 
             var segments = key.Split(':');
-            if (segments.Any(segment => MatchesAddressSegment(segment, typeName, shortName)))
+            if (MatchesAddressKey(segments, typeName, shortName))
                 addresses.Add(kvp.Value);
         }
     }
 
-    private static bool MatchesAddressSegment(string segment, string typeName, string shortName)
+    private static bool MatchesAddressKey(string[] segments, string typeName, string shortName)
     {
-        if (IsExactMatch(segment, typeName, shortName))
+        if (segments.Length == 0)
+            return false;
+
+        var leaf = segments[^1];
+        if (MatchesAddressSegment(leaf, typeName, shortName))
             return true;
 
+        if (segments.Length > 1 && AddressSuffixes.Any(suffix => leaf.Equals(suffix, StringComparison.OrdinalIgnoreCase)))
+        {
+            var parent = segments[^2];
+            return IsExactMatch(parent, typeName, shortName);
+        }
+
+        return false;
+    }
+
+    private static bool MatchesAddressSegment(string segment, string typeName, string shortName)
+    {
         foreach (var suffix in AddressSuffixes)
         {
             if (segment.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) && segment.Length > suffix.Length)

--- a/DRN.Framework.Testing/Contexts/ApplicationContextRouterHandler.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContextRouterHandler.cs
@@ -1,0 +1,326 @@
+using System.Collections.Concurrent;
+
+namespace DRN.Framework.Testing.Contexts;
+
+/// <summary>
+/// Routes HTTP requests across multiple in-memory applications hosted in <see cref="ApplicationContext"/>.
+/// Matches incoming request URIs against registered application test servers, hostnames, ports, and aliases.
+/// </summary>
+public sealed class ApplicationContextRouterHandler : HttpMessageHandler
+{
+    private static readonly string[] Suffixes = ["Program", "App", "Host", "Hosted", "Server", "Service"];
+    private static readonly string[] GenericSegments = ["DRN", "Framework", "Hosted", "Host", "App", "Server", "Service", "Test", "Utils", "Integration", "Unit"];
+
+    private readonly ConcurrentDictionary<string, Func<HttpMessageHandler>> _addressHandlers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<Type, Func<HttpMessageHandler>> _typeHandlers = new();
+    private readonly ConcurrentDictionary<Type, Func<HttpMessageHandler>> _typeResolvers = new();
+    private readonly ConcurrentDictionary<HttpMessageHandler, HttpMessageInvoker> _invokers = new();
+    private Func<HttpMessageHandler>? _singleAppHandler;
+    private int _appCount;
+
+    /// <summary>
+    /// Registers an application entry point and its lazy <see cref="HttpMessageHandler"/> factory with canonical and custom address mappings.
+    /// </summary>
+    public void Register(Type entryPointType, Func<HttpMessageHandler> handlerFactory, IEnumerable<string>? additionalAddresses = null)
+    {
+        ArgumentNullException.ThrowIfNull(entryPointType);
+        ArgumentNullException.ThrowIfNull(handlerFactory);
+
+        var lazyHandler = new Lazy<HttpMessageHandler>(handlerFactory);
+        Func<HttpMessageHandler> resolver = () => lazyHandler.Value;
+
+        _typeHandlers[entryPointType] = resolver;
+
+        // Register canonical type name (e.g. "NexusProgram")
+        RegisterAddress(entryPointType.Name, resolver);
+
+        // Register short name without generic suffixes (e.g. "NexusProgram" -> "Nexus")
+        var shortName = GetShortName(entryPointType.Name);
+        if (!string.Equals(shortName, entryPointType.Name, StringComparison.OrdinalIgnoreCase))
+            RegisterAddress(shortName, resolver);
+
+        // Register assembly name and meaningful segments
+        var assemblyName = entryPointType.Assembly.GetName().Name;
+        if (!string.IsNullOrWhiteSpace(assemblyName))
+        {
+            RegisterAddress(assemblyName, resolver);
+            var parts = assemblyName.Split('.');
+            foreach (var part in parts)
+            {
+                if (!string.IsNullOrWhiteSpace(part) &&
+                    !GenericSegments.Any(g => part.Equals(g, StringComparison.OrdinalIgnoreCase)))
+                {
+                    RegisterAddress(part, resolver);
+                }
+            }
+        }
+
+        if (additionalAddresses != null)
+        {
+            foreach (var addr in additionalAddresses)
+            {
+                if (!string.IsNullOrWhiteSpace(addr))
+                    RegisterAddress(addr, resolver);
+            }
+        }
+
+        Interlocked.Exchange(ref _singleAppHandler, resolver);
+        Interlocked.Increment(ref _appCount);
+    }
+
+    /// <summary>
+    /// Registers an application entry point and its in-memory <see cref="HttpMessageHandler"/> with canonical and custom address mappings.
+    /// </summary>
+    public void Register(Type entryPointType, HttpMessageHandler handler, IEnumerable<string>? additionalAddresses = null) =>
+        Register(entryPointType, () => handler, additionalAddresses);
+
+    /// <summary>
+    /// Explicitly maps a hostname, port, or base URL to a registered application type's lazy handler.
+    /// </summary>
+    public void RegisterAddress(string addressOrHost, Type entryPointType)
+    {
+        ArgumentNullException.ThrowIfNull(entryPointType);
+        var resolver = _typeResolvers.GetOrAdd(entryPointType, t => () => ResolveTypeHandler(t));
+        RegisterAddress(addressOrHost, resolver);
+    }
+
+    /// <summary>
+    /// Explicitly maps a hostname, port, or base URL to a lazy <see cref="HttpMessageHandler"/> factory.
+    /// </summary>
+    public void RegisterAddress(string addressOrHost, Func<HttpMessageHandler> handlerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(addressOrHost);
+        ArgumentNullException.ThrowIfNull(handlerFactory);
+
+        var normalized = NormalizeAddress(addressOrHost);
+        if (string.IsNullOrWhiteSpace(normalized))
+            return;
+
+        _addressHandlers[normalized] = handlerFactory;
+
+        if (int.TryParse(normalized, out var purePort) && purePort > 0)
+        {
+            _addressHandlers[normalized] = handlerFactory;
+            _addressHandlers[$"localhost:{normalized}"] = handlerFactory;
+            _addressHandlers[$"127.0.0.1:{normalized}"] = handlerFactory;
+            _addressHandlers[$"[::1]:{normalized}"] = handlerFactory;
+            return;
+        }
+
+        if (TryExtractHostAndPort(normalized, out var hostPart, out var portPart))
+        {
+            var isWildcardHost = string.IsNullOrWhiteSpace(hostPart) ||
+                                 hostPart.Equals("*", StringComparison.OrdinalIgnoreCase) ||
+                                 hostPart.Equals("+", StringComparison.OrdinalIgnoreCase) ||
+                                 hostPart.Equals("0.0.0.0", StringComparison.OrdinalIgnoreCase);
+
+            if (!isWildcardHost && !string.IsNullOrWhiteSpace(hostPart))
+            {
+                _addressHandlers[hostPart] = handlerFactory;
+                if (hostPart.StartsWith('[') && hostPart.EndsWith(']'))
+                {
+                    var unbracketed = hostPart[1..^1];
+                    if (!string.IsNullOrWhiteSpace(unbracketed))
+                        _addressHandlers[unbracketed] = handlerFactory;
+                }
+            }
+
+            if (int.TryParse(portPart, out var portNum) && portNum > 0)
+            {
+                _addressHandlers[portPart!] = handlerFactory;
+                _addressHandlers[$"localhost:{portPart}"] = handlerFactory;
+                _addressHandlers[$"127.0.0.1:{portPart}"] = handlerFactory;
+                _addressHandlers[$"[::1]:{portPart}"] = handlerFactory;
+                if (!isWildcardHost && !string.IsNullOrWhiteSpace(hostPart))
+                    _addressHandlers[$"{hostPart}:{portPart}"] = handlerFactory;
+            }
+        }
+        else if (normalized.StartsWith('[') && normalized.EndsWith(']'))
+        {
+            var unbracketed = normalized[1..^1];
+            if (!string.IsNullOrWhiteSpace(unbracketed))
+                _addressHandlers[unbracketed] = handlerFactory;
+        }
+    }
+
+    /// <summary>
+    /// Explicitly maps a hostname, port, or base URL to a specific <see cref="HttpMessageHandler"/>.
+    /// </summary>
+    public void RegisterAddress(string addressOrHost, HttpMessageHandler handler) =>
+        RegisterAddress(addressOrHost, () => handler);
+
+    private static bool TryExtractHostAndPort(string normalized, out string? hostPart, out string? portPart)
+    {
+        hostPart = null;
+        portPart = null;
+
+        if (normalized.StartsWith('[') && normalized.IndexOf(']') is var closingIndex and > 0)
+        {
+            hostPart = normalized[..(closingIndex + 1)];
+            if (closingIndex + 1 < normalized.Length && normalized[closingIndex + 1] == ':')
+            {
+                portPart = normalized[(closingIndex + 2)..].TrimEnd('/');
+                return true;
+            }
+
+            return false;
+        }
+
+        var firstColon = normalized.IndexOf(':');
+        var lastColon = normalized.LastIndexOf(':');
+
+        if (firstColon >= 0 && firstColon == lastColon)
+        {
+            hostPart = normalized[..lastColon].Trim().TrimStart('/', '*');
+            portPart = normalized[(lastColon + 1)..].Trim().TrimEnd('/');
+            return true;
+        }
+
+        return false;
+    }
+
+    private HttpMessageHandler ResolveTypeHandler(Type entryPointType)
+    {
+        if (_typeHandlers.TryGetValue(entryPointType, out var handler))
+            return handler();
+
+        throw new InvalidOperationException(
+            $"Application '{entryPointType.Name}' is mapped to an address but has not been created in ApplicationContext.");
+    }
+
+    /// <summary>
+    /// Unregisters an application entry point and its associated handler.
+    /// </summary>
+    public void Unregister(Type entryPointType)
+    {
+        ArgumentNullException.ThrowIfNull(entryPointType);
+
+        if (_typeHandlers.TryRemove(entryPointType, out var handler))
+        {
+            Interlocked.Decrement(ref _appCount);
+            foreach (var kvp in _addressHandlers)
+            {
+                if (ReferenceEquals(kvp.Value, handler))
+                    _addressHandlers.TryRemove(kvp.Key, out _);
+            }
+
+            if (ReferenceEquals(_singleAppHandler, handler))
+                _singleAppHandler = _typeHandlers.Values.FirstOrDefault();
+        }
+    }
+
+    /// <summary>
+    /// Clears all registered applications and addresses.
+    /// </summary>
+    public void Clear()
+    {
+        _addressHandlers.Clear();
+        _typeHandlers.Clear();
+        _typeResolvers.Clear();
+        _invokers.Clear();
+        _singleAppHandler = null;
+        _appCount = 0;
+    }
+
+    /// <summary>
+    /// Creates a non-owning forwarding handler that delegates requests to this router without disposing or clearing router state when closed.
+    /// </summary>
+    public HttpMessageHandler CreateForwardingHandler() => new NonDisposingForwardingHandler(this);
+
+    internal Task<HttpResponseMessage> SendRoutedAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+        SendAsync(request, cancellationToken);
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var handler = ResolveHandler(request);
+        var invoker = _invokers.GetOrAdd(handler, static h => new HttpMessageInvoker(h, disposeHandler: false));
+
+        return invoker.SendAsync(request, cancellationToken);
+    }
+
+    private HttpMessageHandler ResolveHandler(HttpRequestMessage request)
+    {
+        var uri = request.RequestUri;
+        if (uri == null)
+            throw new InvalidOperationException("HttpRequestMessage RequestUri cannot be null.");
+
+        Func<HttpMessageHandler>? resolver = null;
+
+        // 1. Match by authority (host:port, e.g. "localhost:5988" or "nexus:80")
+        if (_addressHandlers.TryGetValue(uri.Authority, out var authorityHandler))
+            resolver = authorityHandler;
+        // 2. Match by host:port
+        else if (uri.Port > 0 && _addressHandlers.TryGetValue($"{uri.Host}:{uri.Port}", out var hostPortHandler))
+            resolver = hostPortHandler;
+        // 3. Match by host (e.g. "nexus", "sample")
+        else if (_addressHandlers.TryGetValue(uri.Host, out var hostHandler))
+            resolver = hostHandler;
+        // 4. Match by port alone (e.g. "5988")
+        else if (uri.Port > 0 && _addressHandlers.TryGetValue(uri.Port.ToString(), out var portHandler))
+            resolver = portHandler;
+        // 5. Match by Host header if present
+        else if (request.Headers.Host != null && _addressHandlers.TryGetValue(request.Headers.Host, out var headerHandler))
+            resolver = headerHandler;
+        // 6. Fallback for single registered application targeting localhost
+        else if (_appCount == 1 && _singleAppHandler != null && (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) || uri.Host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)))
+            resolver = _singleAppHandler;
+
+        if (resolver != null)
+            return resolver();
+
+        var registered = string.Join(", ", _addressHandlers.Keys);
+        var registeredTypes = string.Join(", ", _typeHandlers.Keys.Select(t => t.Name));
+
+        throw new InvalidOperationException(
+            $"No application registered in ApplicationContext matches host '{uri.Host}' (Authority: '{uri.Authority}', Port: {uri.Port}). " +
+            $"Registered addresses: [{registered}]. Registered applications: [{registeredTypes}].");
+    }
+
+    public static string GetShortName(string typeName)
+    {
+        foreach (var suffix in Suffixes)
+        {
+            if (typeName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) && typeName.Length > suffix.Length)
+                return typeName[..^suffix.Length];
+        }
+
+        return typeName;
+    }
+
+    private static string NormalizeAddress(string address)
+    {
+        address = address.Trim().TrimEnd('/');
+        if (address.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            address = address["http://".Length..];
+        else if (address.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            address = address["https://".Length..];
+
+        var slashIndex = address.IndexOf('/');
+        if (slashIndex >= 0)
+            address = address[..slashIndex];
+
+        return address.TrimEnd('/');
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            Clear();
+
+        base.Dispose(disposing);
+    }
+
+    private sealed class NonDisposingForwardingHandler(ApplicationContextRouterHandler routerHandler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            routerHandler.SendRoutedAsync(request, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            // Non-owning wrapper; do not dispose or clear the shared routerHandler.
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/DRN.Framework.Testing/Contexts/ApplicationContextRouterHandler.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContextRouterHandler.cs
@@ -16,7 +16,6 @@ public sealed class ApplicationContextRouterHandler : HttpMessageHandler
     private readonly ConcurrentDictionary<Type, Func<HttpMessageHandler>> _typeResolvers = new();
     private readonly ConcurrentDictionary<HttpMessageHandler, HttpMessageInvoker> _invokers = new();
     private Func<HttpMessageHandler>? _singleAppHandler;
-    private int _appCount;
 
     /// <summary>
     /// Registers an application entry point and its lazy <see cref="HttpMessageHandler"/> factory with canonical and custom address mappings.
@@ -65,7 +64,6 @@ public sealed class ApplicationContextRouterHandler : HttpMessageHandler
         }
 
         Interlocked.Exchange(ref _singleAppHandler, resolver);
-        Interlocked.Increment(ref _appCount);
     }
 
     /// <summary>
@@ -197,7 +195,6 @@ public sealed class ApplicationContextRouterHandler : HttpMessageHandler
 
         if (_typeHandlers.TryRemove(entryPointType, out var handler))
         {
-            Interlocked.Decrement(ref _appCount);
             foreach (var kvp in _addressHandlers)
             {
                 if (ReferenceEquals(kvp.Value, handler))
@@ -219,7 +216,6 @@ public sealed class ApplicationContextRouterHandler : HttpMessageHandler
         _typeResolvers.Clear();
         _invokers.Clear();
         _singleAppHandler = null;
-        _appCount = 0;
     }
 
     /// <summary>
@@ -264,7 +260,7 @@ public sealed class ApplicationContextRouterHandler : HttpMessageHandler
         else if (request.Headers.Host != null && _addressHandlers.TryGetValue(request.Headers.Host, out var headerHandler))
             resolver = headerHandler;
         // 6. Fallback for single registered application targeting localhost
-        else if (_appCount == 1 && _singleAppHandler != null && (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) || uri.Host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)))
+        else if (_typeHandlers.Count == 1 && _singleAppHandler != null && (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) || uri.Host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)))
             resolver = _singleAppHandler;
 
         if (resolver != null)

--- a/DRN.Framework.Testing/Contexts/ApplicationContextRouterHandler.cs
+++ b/DRN.Framework.Testing/Contexts/ApplicationContextRouterHandler.cs
@@ -253,8 +253,8 @@ public sealed class ApplicationContextRouterHandler : HttpMessageHandler
         // 3. Match by host (e.g. "nexus", "sample")
         else if (_addressHandlers.TryGetValue(uri.Host, out var hostHandler))
             resolver = hostHandler;
-        // 4. Match by port alone (e.g. "5988")
-        else if (uri.Port > 0 && _addressHandlers.TryGetValue(uri.Port.ToString(), out var portHandler))
+        // 4. Match by port alone for non-default ports (e.g. "5988")
+        else if (uri.Port > 0 && !uri.IsDefaultPort && _addressHandlers.TryGetValue(uri.Port.ToString(), out var portHandler))
             resolver = portHandler;
         // 5. Match by Host header if present
         else if (request.Headers.Host != null && _addressHandlers.TryGetValue(request.Headers.Host, out var headerHandler))

--- a/DRN.Framework.Testing/DRN.Framework.Testing.csproj
+++ b/DRN.Framework.Testing/DRN.Framework.Testing.csproj
@@ -48,7 +48,7 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture.AutoNSubstitute" Version="5.0.0-rc.1"/>
         <PackageReference Include="AutoFixture.Xunit3" Version="5.0.0-rc.1"/>
-        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
         <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="1.0.0-alpha.26377.5" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />

--- a/DRN.Framework.Testing/README.md
+++ b/DRN.Framework.Testing/README.md
@@ -302,7 +302,7 @@ or infrastructure module, then use `EnsureDatabaseAsync` to create the schema di
 - **Using Factory and Client Together for the Same Application**:
   - **Pattern 1 (Recommended)**: Call `var client = await context.ApplicationContext.CreateClientAsync<T>();` and retrieve the underlying factory via `var factory = context.ApplicationContext.GetCreatedApplication<T>();`.
   - **Pattern 2**: Call `var app = await context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<T>();` and call `var client = app.CreateClient();`.
-- Outbound HTTP requests between hosted applications (via `IInternalRequest`, `IExternalRequest`, Flurl, and `IHttpClientFactory`) are automatically routed in-memory via `ApplicationContextRouterHandler` using hostnames, ports, and aliases (e.g. `nexus`, `localhost:5988`).
+- Outbound HTTP requests between hosted applications (via `IInternalRequest`, `IExternalRequest`, Flurl, and `IHttpClientFactory`) are automatically routed in-memory via `ApplicationContextRouterHandler` using hostnames, ports, and aliases (e.g. `nexus`, `localhost:5988`). Requests to unregistered hosts fail with `InvalidOperationException` rather than reaching the network; handle external endpoints using in-memory mock applications (`ApplicationContext.MapAddress`) or declarative Flurl mocking (`FlurlHttpTest`).
 - `CreateClientForServiceAsync<TProgram>("service-alias")` and `ApplicationContext.MapAddress<TProgram>("service-alias")` allow registering custom DNS names or service aliases for an application.
 - `CreateClientAsync<TProgram>()` calls `ContainerContext.BindExternalDependenciesAsync()`, which applies Postgres migrations for registered `DrnContext` types. It does not start RabbitMQ.
 - When each application is created, `ApplicationContext` automatically captures logs only while a debugger is attached and
@@ -338,6 +338,30 @@ public async Task MultiApp_Should_Route_Between_Services(DrnTestContext context)
     forecasts.Should().NotBeNull();
 }
 ```
+
+#### Handling External & Third-Party Requests
+
+For outbound calls to external dependencies (e.g. `IExternalRequest`, payment gateways, OAuth providers, notification services), two testing approaches are supported:
+
+1. **In-Memory Mock Applications (`ApplicationContext.MapAddress` / `CreateClientForServiceAsync`)**:
+   - Host a lightweight mock application or Minimal API mapped directly to the external hostname (e.g. `api.stripe.com`).
+   - Ideal for stateful provider simulation, complete HTTP pipeline fidelity (real headers, status codes, payload negotiation), and bidirectional webhook callbacks without altering production code or URLs.
+   ```csharp
+   // Map an in-memory mock app directly to the third-party domain:
+   await context.ApplicationContext.CreateClientForServiceAsync<MockPaymentProviderProgram>("api.stripe.com");
+   // Outbound requests to "https://api.stripe.com/..." route in-memory to MockPaymentProviderProgram
+   ```
+
+2. **Declarative Flurl Mocking (`FlurlHttpTest`)**:
+   - Intercept and stub responses declaratively via `context.FlurlHttpTest.ForCallsTo(...)`.
+   - Ideal for fast, stateless payload assertions, error status simulation (e.g. 422, 500), and call count verification without extra application overhead.
+   ```csharp
+   context.FlurlHttpTest.ForCallsTo("https://api.stripe.com/*")
+       .RespondWithJson(new { id = "ch_123", status = "succeeded" }, 200);
+   ```
+
+> [!NOTE]
+> Requests to unmapped and unmocked external hosts fail immediately with `InvalidOperationException`, ensuring integration tests never accidentally leak physical network calls over the wire.
 
 ### Basic Usage
 

--- a/DRN.Framework.Testing/README.md
+++ b/DRN.Framework.Testing/README.md
@@ -297,7 +297,13 @@ or infrastructure module, then use `EnsureDatabaseAsync` to create the schema di
 `ApplicationContext` syncs `DrnTestContext` service collection and configuration with a `WebApplicationFactory`.
 
 - You can override configuration and services until the factory builds a host, such as when `CreateClient()` or `TestServer` is requested.
-- Creating another application first disposes the current factory; the new application uses the current test configuration and service registrations.
+- `ApplicationContext` supports hosting multiple distinct application entry points concurrently (e.g. `SampleProgram` and `NexusProgram`).
+- **Single Instance Per Type Lifecycle**: `ApplicationContext` manages one active instance per application type. Re-creating the same entry point type (via `CreateApplication` or `CreateClientAsync`) disposes and replaces only that specific application instance.
+- **Using Factory and Client Together for the Same Application**:
+  - **Pattern 1 (Recommended)**: Call `var client = await context.ApplicationContext.CreateClientAsync<T>();` and retrieve the underlying factory via `var factory = context.ApplicationContext.GetCreatedApplication<T>();`.
+  - **Pattern 2**: Call `var app = await context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<T>();` and call `var client = app.CreateClient();`.
+- Outbound HTTP requests between hosted applications (via `IInternalRequest`, `IExternalRequest`, Flurl, and `IHttpClientFactory`) are automatically routed in-memory via `ApplicationContextRouterHandler` using hostnames, ports, and aliases (e.g. `nexus`, `localhost:5988`).
+- `CreateClientForServiceAsync<TProgram>("service-alias")` and `ApplicationContext.MapAddress<TProgram>("service-alias")` allow registering custom DNS names or service aliases for an application.
 - `CreateClientAsync<TProgram>()` calls `ContainerContext.BindExternalDependenciesAsync()`, which applies Postgres migrations for registered `DrnContext` types. It does not start RabbitMQ.
 - When each application is created, `ApplicationContext` automatically captures logs only while a debugger is attached and
   `Xunit.TestContext.Current.TestOutputHelper` is available; otherwise, automatic logging remains disabled.
@@ -306,6 +312,32 @@ or infrastructure module, then use `EnsureDatabaseAsync` to create the schema di
 - By default, without debugger-enabled output logging, application lifecycle logs are not written to shared test-runner output.
 - `TestEnvironment.DrnTestContextEnabled = true` identifies test execution and prevents local development provisioning from
   colliding with integration tests. `TemporaryApplication` is not a general test marker.
+
+### Multi-Application & In-Memory Service Routing
+
+Run multiple applications and route HTTP calls between them in-memory without physical network sockets or port allocation:
+
+```csharp
+[Theory]
+[DataInline]
+public async Task MultiApp_Should_Route_Between_Services(DrnTestContext context)
+{
+    // Host Nexus and Sample concurrently with service aliases
+    var nexusClient = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("nexus-service");
+    var sampleClient = await context.ApplicationContext.CreateClientForServiceAsync<SampleProgram>("sample-service");
+
+    // Access the underlying factory for DI inspection if needed
+    var sampleApp = context.ApplicationContext.GetCreatedApplication<SampleProgram>();
+    using var scope = sampleApp!.Services.CreateScope();
+
+    // Map additional address aliases at any time:
+    context.ApplicationContext.MapAddress<NexusProgram>("custom-nexus-host");
+
+    // Outbound requests via IInternalRequest or HttpClient in SampleProgram route to NexusProgram in-memory
+    var forecasts = await sampleClient.GetFromJsonAsync<WeatherForecast[]>("/Api/Sample/WeatherForecast/Nexus");
+    forecasts.Should().NotBeNull();
+}
+```
 
 ### Basic Usage
 

--- a/DRN.Framework.Testing/RELEASE-NOTES.md
+++ b/DRN.Framework.Testing/RELEASE-NOTES.md
@@ -9,10 +9,6 @@ Not every version includes changes, features or bug fixes. This project can incr
 *   **Custom Service Aliases & Address Mapping**: Added `CreateClientForServiceAsync<TEntryPoint>("service-alias")` and `ApplicationContext.MapAddress<TEntryPoint>("address")` enabling explicit mapping of custom domain names, Kubernetes service names, and ports to hosted applications.
 *   **Automatic Configuration Address Discovery**: `ApplicationContext` automatically discovers and registers service hostnames, ports, and aliases from configuration (`Kestrel:Endpoints`, `*Address`, `*Url`, `*Uri`), enabling seamless in-memory routing between microservices and platform dependencies without manual boilerplate.
 
-### Bug Fixes
-
-*   **Application Factory Lookup Safety**: `ApplicationContext` now keys injected factories by their application entry-point type and returns `null` instead of throwing when a stored factory is incompatible with the requested entry point.
-
 ## Version 0.9.8
 
 Dependencies upgraded to dotnet 10.0.11

--- a/DRN.Framework.Testing/RELEASE-NOTES.md
+++ b/DRN.Framework.Testing/RELEASE-NOTES.md
@@ -2,7 +2,12 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 ## Version 0.9.9
 
-Version alignment release; no package-specific behavior changes.
+### New Features
+
+*   **Multi-Application Integration Testing**: `ApplicationContext` now supports running multiple distinct `WebApplicationFactory<TEntryPoint>` instances concurrently within a single test context.
+*   **In-Memory HTTP Routing**: Added `ApplicationContextRouterHandler` which intercepts outbound requests from `IInternalRequest`, `IExternalRequest`, Flurl, and `IHttpClientFactory` and routes them by host, port, alias, and configured addresses directly to target in-memory `TestServer` instances across multi-tier chains (e.g. A -> B -> C -> B -> A).
+*   **Custom Service Aliases & Address Mapping**: Added `CreateClientForServiceAsync<TEntryPoint>("service-alias")` and `ApplicationContext.MapAddress<TEntryPoint>("address")` enabling explicit mapping of custom domain names, Kubernetes service names, and ports to hosted applications.
+*   **Automatic Configuration Address Discovery**: `ApplicationContext` automatically discovers and registers service hostnames, ports, and aliases from configuration (`Kestrel:Endpoints`, `*Address`, `*Url`, `*Uri`), enabling seamless in-memory routing between microservices and platform dependencies without manual boilerplate.
 
 ## Version 0.9.8
 

--- a/DRN.Framework.Testing/RELEASE-NOTES.md
+++ b/DRN.Framework.Testing/RELEASE-NOTES.md
@@ -9,6 +9,10 @@ Not every version includes changes, features or bug fixes. This project can incr
 *   **Custom Service Aliases & Address Mapping**: Added `CreateClientForServiceAsync<TEntryPoint>("service-alias")` and `ApplicationContext.MapAddress<TEntryPoint>("address")` enabling explicit mapping of custom domain names, Kubernetes service names, and ports to hosted applications.
 *   **Automatic Configuration Address Discovery**: `ApplicationContext` automatically discovers and registers service hostnames, ports, and aliases from configuration (`Kestrel:Endpoints`, `*Address`, `*Url`, `*Uri`), enabling seamless in-memory routing between microservices and platform dependencies without manual boilerplate.
 
+### Bug Fixes
+
+*   **Application Factory Lookup Safety**: `ApplicationContext` now keys injected factories by their application entry-point type and returns `null` instead of throwing when a stored factory is incompatible with the requested entry point.
+
 ## Version 0.9.8
 
 Dependencies upgraded to dotnet 10.0.11

--- a/DRN.Framework.Testing/packages.lock.json
+++ b/DRN.Framework.Testing/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "AwesomeAssertions": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
@@ -754,8 +754,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -958,7 +958,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"

--- a/DRN.Framework.Utils/Http/ExternalRequest.cs
+++ b/DRN.Framework.Utils/Http/ExternalRequest.cs
@@ -15,36 +15,16 @@ public interface IExternalRequest
 }
 
 [Singleton<IExternalRequest>]
-public class ExternalRequest : IExternalRequest
+public class ExternalRequest(HttpMessageHandler? httpMessageHandler) : IExternalRequest
 {
     private static readonly DefaultJsonSerializer JsonSerializer = new(JsonConventions.DefaultOptions);
-    private readonly IFlurlClient? _flurlClient;
+    private readonly IFlurlClient? _flurlClient = httpMessageHandler != null ? new FlurlClient(new HttpClient(httpMessageHandler, disposeHandler: false)) : null;
 
     public ExternalRequest() : this(null)
     {
     }
 
-    public ExternalRequest(HttpMessageHandler? httpMessageHandler)
-    {
-        _flurlClient = httpMessageHandler != null ? new FlurlClient(new HttpClient(httpMessageHandler, disposeHandler: false)) : null;
-    }
-
     public IFlurlRequest For(Url endpoint, Version httpVersion) => For(endpoint, httpVersion.ToString());
 
-    private IFlurlRequest For(Url endpoint, string httpVersion)
-    {
-        var flurlRequest = _flurlClient != null
-            ? _flurlClient.Request(endpoint)
-            : new FlurlRequest(endpoint);
-
-        flurlRequest.WithSettings(x =>
-        {
-            x.HttpVersion = httpVersion;
-            x.JsonSerializer = JsonSerializer;
-        });
-
-        flurlRequest.BeforeCall(x => x.HttpRequestMessage.VersionPolicy = HttpVersionPolicy.RequestVersionExact);
-
-        return flurlRequest;
-    }
+    private IFlurlRequest For(Url endpoint, string httpVersion) => FlurlRequestFactory.Create(_flurlClient, endpoint, httpVersion, JsonSerializer);
 }

--- a/DRN.Framework.Utils/Http/ExternalRequest.cs
+++ b/DRN.Framework.Utils/Http/ExternalRequest.cs
@@ -18,12 +18,26 @@ public interface IExternalRequest
 public class ExternalRequest : IExternalRequest
 {
     private static readonly DefaultJsonSerializer JsonSerializer = new(JsonConventions.DefaultOptions);
+    private readonly IFlurlClient? _flurlClient;
+
+    public ExternalRequest() : this(null)
+    {
+    }
+
+    public ExternalRequest(HttpMessageHandler? httpMessageHandler)
+    {
+        _flurlClient = httpMessageHandler != null ? new FlurlClient(new HttpClient(httpMessageHandler, disposeHandler: false)) : null;
+    }
 
     public IFlurlRequest For(Url endpoint, Version httpVersion) => For(endpoint, httpVersion.ToString());
 
-    private static IFlurlRequest For(Url endpoint, string httpVersion)
+    private IFlurlRequest For(Url endpoint, string httpVersion)
     {
-        var flurlRequest = endpoint.WithSettings(x =>
+        var flurlRequest = _flurlClient != null
+            ? _flurlClient.Request(endpoint)
+            : new FlurlRequest(endpoint);
+
+        flurlRequest.WithSettings(x =>
         {
             x.HttpVersion = httpVersion;
             x.JsonSerializer = JsonSerializer;

--- a/DRN.Framework.Utils/Http/FlurlRequestFactory.cs
+++ b/DRN.Framework.Utils/Http/FlurlRequestFactory.cs
@@ -1,0 +1,25 @@
+using Flurl;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+
+namespace DRN.Framework.Utils.Http;
+
+internal static class FlurlRequestFactory
+{
+    public static IFlurlRequest Create(IFlurlClient? flurlClient, Url url, string httpVersion, DefaultJsonSerializer jsonSerializer)
+    {
+        var flurlRequest = flurlClient != null
+            ? flurlClient.Request(url)
+            : new FlurlRequest(url);
+
+        flurlRequest.WithSettings(x =>
+        {
+            x.HttpVersion = httpVersion;
+            x.JsonSerializer = jsonSerializer;
+        });
+
+        flurlRequest.BeforeCall(x => x.HttpRequestMessage.VersionPolicy = HttpVersionPolicy.RequestVersionExact);
+
+        return flurlRequest;
+    }
+}

--- a/DRN.Framework.Utils/Http/InternalRequest.cs
+++ b/DRN.Framework.Utils/Http/InternalRequest.cs
@@ -1,6 +1,7 @@
 using DRN.Framework.SharedKernel.Json;
 using DRN.Framework.Utils.DependencyInjection.Attributes;
 using DRN.Framework.Utils.Settings;
+using Flurl;
 using Flurl.Http;
 using Flurl.Http.Configuration;
 
@@ -41,14 +42,27 @@ public interface IInternalRequest
 }
 
 [Singleton<IInternalRequest>]
-public class InternalRequest(IAppSettings appSettings) : IInternalRequest
+public class InternalRequest : IInternalRequest
 {
     private const string Http = "http://";
     private const string Https = "https://";
 
     private static readonly DefaultJsonSerializer JsonSerializer = new(JsonConventions.DefaultOptions);
-    private readonly string _httpVersionDefault = new Version(appSettings.Features.InternalRequestHttpVersion).ToString();
-    private readonly bool _securityDefault = appSettings.Features.InternalRequestProtocol.StartsWith("https", StringComparison.OrdinalIgnoreCase);
+    private readonly string _httpVersionDefault;
+    private readonly bool _securityDefault;
+    private readonly IFlurlClient? _flurlClient;
+
+    public InternalRequest(IAppSettings appSettings)
+        : this(appSettings, null)
+    {
+    }
+
+    public InternalRequest(IAppSettings appSettings, HttpMessageHandler? httpMessageHandler)
+    {
+        _httpVersionDefault = new Version(appSettings.Features.InternalRequestHttpVersion).ToString();
+        _securityDefault = appSettings.Features.InternalRequestProtocol.StartsWith("https", StringComparison.OrdinalIgnoreCase);
+        _flurlClient = httpMessageHandler != null ? new FlurlClient(new HttpClient(httpMessageHandler, disposeHandler: false)) : null;
+    }
 
     public IFlurlRequest For(string service) => For(service, _securityDefault, _httpVersionDefault);
     public IFlurlRequest For(string service, bool secure) => For(service, secure, _httpVersionDefault);
@@ -59,10 +73,15 @@ public class InternalRequest(IAppSettings appSettings) : IInternalRequest
     /// <param name="httpVersion">1.1 or 2.0</param>
     public IFlurlRequest For(string service, bool secure, Version httpVersion) => For(service, secure, httpVersion.ToString());
 
-    private static IFlurlRequest For(string service, bool secure, string httpVersion)
+    private IFlurlRequest For(string service, bool secure, string httpVersion)
     {
         var protocol = secure ? Https : Http;
-        var flurlRequest = $"{protocol}{service}".WithSettings(x =>
+        var url = $"{protocol}{service}";
+        var flurlRequest = _flurlClient != null
+            ? _flurlClient.Request(url)
+            : new FlurlRequest(url);
+
+        flurlRequest.WithSettings(x =>
         {
             x.HttpVersion = httpVersion;
             x.JsonSerializer = JsonSerializer;

--- a/DRN.Framework.Utils/Http/InternalRequest.cs
+++ b/DRN.Framework.Utils/Http/InternalRequest.cs
@@ -42,26 +42,18 @@ public interface IInternalRequest
 }
 
 [Singleton<IInternalRequest>]
-public class InternalRequest : IInternalRequest
+public class InternalRequest(IAppSettings appSettings, HttpMessageHandler? httpMessageHandler) : IInternalRequest
 {
     private const string Http = "http://";
     private const string Https = "https://";
 
     private static readonly DefaultJsonSerializer JsonSerializer = new(JsonConventions.DefaultOptions);
-    private readonly string _httpVersionDefault;
-    private readonly bool _securityDefault;
-    private readonly IFlurlClient? _flurlClient;
+    private readonly string _httpVersionDefault = new Version(appSettings.Features.InternalRequestHttpVersion).ToString();
+    private readonly bool _securityDefault = appSettings.Features.InternalRequestProtocol.StartsWith("https", StringComparison.OrdinalIgnoreCase);
+    private readonly IFlurlClient? _flurlClient = httpMessageHandler != null ? new FlurlClient(new HttpClient(httpMessageHandler, disposeHandler: false)) : null;
 
-    public InternalRequest(IAppSettings appSettings)
-        : this(appSettings, null)
+    public InternalRequest(IAppSettings appSettings) : this(appSettings, null)
     {
-    }
-
-    public InternalRequest(IAppSettings appSettings, HttpMessageHandler? httpMessageHandler)
-    {
-        _httpVersionDefault = new Version(appSettings.Features.InternalRequestHttpVersion).ToString();
-        _securityDefault = appSettings.Features.InternalRequestProtocol.StartsWith("https", StringComparison.OrdinalIgnoreCase);
-        _flurlClient = httpMessageHandler != null ? new FlurlClient(new HttpClient(httpMessageHandler, disposeHandler: false)) : null;
     }
 
     public IFlurlRequest For(string service) => For(service, _securityDefault, _httpVersionDefault);
@@ -77,18 +69,6 @@ public class InternalRequest : IInternalRequest
     {
         var protocol = secure ? Https : Http;
         var url = $"{protocol}{service}";
-        var flurlRequest = _flurlClient != null
-            ? _flurlClient.Request(url)
-            : new FlurlRequest(url);
-
-        flurlRequest.WithSettings(x =>
-        {
-            x.HttpVersion = httpVersion;
-            x.JsonSerializer = JsonSerializer;
-        });
-
-        flurlRequest.BeforeCall(x => x.HttpRequestMessage.VersionPolicy = HttpVersionPolicy.RequestVersionExact);
-
-        return flurlRequest;
+        return FlurlRequestFactory.Create(_flurlClient, url, httpVersion, JsonSerializer);
     }
 }

--- a/DRN.Framework.Utils/README.md
+++ b/DRN.Framework.Utils/README.md
@@ -539,6 +539,10 @@ public class NexusClient(INexusRequest request) : INexusClient
 }
 ```
 
+### Primary Handler Injection
+
+`InternalRequest` and `ExternalRequest` accept an optional `HttpMessageHandler?` via constructor dependency injection. When an `HttpMessageHandler` is registered in DI (such as `ApplicationContextRouterHandler` during integration testing), `FlurlClient` instances use the injected handler for in-memory routing and interception without modifying global static Flurl state.
+
 Buffered response converters (`ToStringAsync`, `ToBytesAsync`, and `FromJsonAsync`) capture `HttpStatus` and `Payload`, then dispose the response even if reading or deserialization fails.
 Call converters as extension methods on `Task<IFlurlResponse>` or `IFlurlResponse`; `HttpResponse` models the converted result and no longer exposes static conversion entry points.
 

--- a/DRN.Framework.Utils/RELEASE-NOTES.md
+++ b/DRN.Framework.Utils/RELEASE-NOTES.md
@@ -2,7 +2,9 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 ## Version 0.9.9
 
-Version alignment release; no package-specific behavior changes.
+### New Features
+
+*   **HttpMessageHandler DI Injection**: `InternalRequest` and `ExternalRequest` now accept an optional `HttpMessageHandler?` via dependency injection, allowing in-memory routing handlers (such as `ApplicationContextRouterHandler` during integration testing) to intercept and route Flurl calls without global static cache mutation.
 
 ## Version 0.9.8
 

--- a/DRN.Framework.Utils/Settings/NexusAppSettings.cs
+++ b/DRN.Framework.Utils/Settings/NexusAppSettings.cs
@@ -15,9 +15,11 @@ public sealed class NexusAppSettings : IDisposable
 {
     private IReadOnlyList<NexusKey> _keys = [];
 
+    public const string DefaultNexusAddress = "nexus";
+
     public static string GetKey(string shortKey) => $"{nameof(NexusAppSettings)}:{shortKey}";
 
-    public string NexusAddress { get; init; } = "nexus";
+    public string NexusAddress { get; init; } = DefaultNexusAddress;
 
     //Nexus App will generate ids randomly in production
     public byte AppId { get; init; }

--- a/DRN.Nexus.Hosted/Controllers/Sample/StatusController.cs
+++ b/DRN.Nexus.Hosted/Controllers/Sample/StatusController.cs
@@ -1,11 +1,10 @@
 using DRN.Framework.Utils.Configurations;
 using DRN.Framework.Utils.Settings;
-using Microsoft.AspNetCore.Http;
 
 namespace DRN.Nexus.Hosted.Controllers.Sample;
 
 [ApiController]
-[Route(NexusEndpointFor.ControllerRouteTemplate)]
+[Route(SampleApiFor.ControllerRouteTemplate)]
 public class StatusController(IAppSettings appSettings) : ControllerBase
 {
     [HttpGet]

--- a/DRN.Nexus.Hosted/Controllers/Sample/WeatherForecastController.cs
+++ b/DRN.Nexus.Hosted/Controllers/Sample/WeatherForecastController.cs
@@ -1,10 +1,8 @@
 using DRN.Framework.Hosting.HealthCheck;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 
 namespace DRN.Nexus.Hosted.Controllers.Sample;
 
-[Route(NexusEndpointFor.ControllerRouteTemplate)]
+[Route(SampleApiFor.ControllerRouteTemplate)]
 public class WeatherForecastController : WeatherForecastControllerBase
 {
     [HttpGet("private")]

--- a/DRN.Nexus.Hosted/Controllers/User/NexusIdentityControllers.cs
+++ b/DRN.Nexus.Hosted/Controllers/User/NexusIdentityControllers.cs
@@ -1,7 +1,6 @@
 using DRN.Framework.Hosting.Endpoints;
 using DRN.Framework.Hosting.Identity.Controllers;
 using DRN.Nexus.Domain.User;
-using DRN.Nexus.Hosted.Helpers;
 
 namespace DRN.Nexus.Hosted.Controllers.User;
 

--- a/DRN.Nexus.Hosted/Helpers/EndpointFor/SampleApiFor.cs
+++ b/DRN.Nexus.Hosted/Helpers/EndpointFor/SampleApiFor.cs
@@ -1,27 +1,27 @@
 using DRN.Framework.Hosting.Endpoints;
+using DRN.Framework.Hosting.Nexus;
 using DRN.Nexus.Hosted.Controllers.Sample;
 
-namespace DRN.Nexus.Hosted.Controllers;
+namespace DRN.Nexus.Hosted.Helpers.EndpointFor;
 
-public class NexusEndpointFor : EndpointCollectionBase<NexusProgram>
+public class SampleApiFor
 {
-    public const string Prefix = "/Api";
+    public const string Prefix = $"/{NexusEndpoints.Prefix}";
     public const string ControllerRouteTemplate = $"{Prefix}/[controller]";
 
-    public UserApiFor User { get; } = new();
     public StatusFor Status { get; } = new();
     public WeatherForecastFor WeatherForecast { get; } = new();
 }
 
 public class StatusFor()
-    : ControllerForBase<StatusController>(NexusEndpointFor.ControllerRouteTemplate)
+    : ControllerForBase<StatusController>(SampleApiFor.ControllerRouteTemplate)
 {
     //By convention Endpoint name should match Action name and property should have setter;
     public ApiEndpoint Status { get; private set; } = null!;
 }
 
 public class WeatherForecastFor()
-    : ControllerForBase<WeatherForecastController>(NexusEndpointFor.ControllerRouteTemplate)
+    : ControllerForBase<WeatherForecastController>(SampleApiFor.ControllerRouteTemplate)
 {
     //By convention Endpoint name should match Action name and property should have setter;
     public ApiEndpoint Get { get; private set; } = null!;

--- a/DRN.Nexus.Hosted/Helpers/EndpointFor/UserApiFor.cs
+++ b/DRN.Nexus.Hosted/Helpers/EndpointFor/UserApiFor.cs
@@ -1,11 +1,12 @@
 using DRN.Framework.Hosting.Endpoints;
+using DRN.Framework.Hosting.Nexus;
 using DRN.Nexus.Hosted.Controllers.User;
 
-namespace DRN.Nexus.Hosted.Controllers;
+namespace DRN.Nexus.Hosted.Helpers.EndpointFor;
 
 public class UserApiFor
 {
-    public const string Prefix = "/Api/User";
+    public const string Prefix = $"/{NexusEndpoints.User}";
     public const string ControllerRouteTemplate = $"{Prefix}/[controller]";
 
     public UserIdentityFor Identity { get; } = new();
@@ -16,12 +17,15 @@ public class UserIdentityFor
     //By convention Endpoint name should match Action name and property should have setter;
     public UserIdentityRegisterFor RegisterController { get; } = new();
     public UserIdentityLoginFor LoginController { get; } = new();
+    public UserIdentityPasswordFor PasswordController { get; } = new();
+    public UserIdentityManagementFor ManagementController { get; } = new();
 }
 
 public class UserIdentityLoginFor() : ControllerForBase<NexusIdentityLoginController>(UserApiFor.ControllerRouteTemplate)
 {
     //By convention Endpoint name should match Action name and property should have setter;
     public ApiEndpoint Login { get; private set; } = null!;
+    public ApiEndpoint Refresh { get; private set; } = null!;
 }
 
 public class UserIdentityRegisterFor() : ControllerForBase<NexusIdentityRegister>(UserApiFor.ControllerRouteTemplate)
@@ -31,4 +35,20 @@ public class UserIdentityRegisterFor() : ControllerForBase<NexusIdentityRegister
 
     //By convention Endpoint name should match Action name and property should have setter;
     public ApiEndpoint ConfirmEmail { get; private set; } = null!;
+    public ApiEndpoint ResendConfirmationEmail { get; private set; } = null!;
+}
+
+public class UserIdentityPasswordFor() : ControllerForBase<NexusIdentityPasswordController>(UserApiFor.ControllerRouteTemplate)
+{
+    //By convention Endpoint name should match Action name and property should have setter;
+    public ApiEndpoint Forgot { get; private set; } = null!;
+    public ApiEndpoint Reset { get; private set; } = null!;
+}
+
+public class UserIdentityManagementFor() : ControllerForBase<NexusIdentityManagementController>(UserApiFor.ControllerRouteTemplate)
+{
+    //By convention Endpoint name should match Action name and property should have setter;
+    public ApiEndpoint TwoFactorAuth { get; private set; } = null!;
+    public ApiEndpoint GetInfo { get; private set; } = null!;
+    public ApiEndpoint PostInfo { get; private set; } = null!;
 }

--- a/DRN.Nexus.Hosted/Helpers/EndpointFor/_NexusEndpointFor.cs
+++ b/DRN.Nexus.Hosted/Helpers/EndpointFor/_NexusEndpointFor.cs
@@ -1,0 +1,9 @@
+using DRN.Framework.Hosting.Endpoints;
+
+namespace DRN.Nexus.Hosted.Helpers.EndpointFor;
+
+public class NexusEndpointFor : EndpointCollectionBase<NexusProgram>
+{
+    public UserApiFor User { get; } = new();
+    public SampleApiFor Sample { get; } = new();
+}

--- a/DRN.Nexus.Hosted/Helpers/_Get.cs
+++ b/DRN.Nexus.Hosted/Helpers/_Get.cs
@@ -1,5 +1,4 @@
 using DRN.Framework.Hosting.Endpoints;
-using DRN.Nexus.Hosted.Controllers;
 
 namespace DRN.Nexus.Hosted.Helpers;
 

--- a/DRN.Nexus.Hosted/Usings.cs
+++ b/DRN.Nexus.Hosted/Usings.cs
@@ -1,4 +1,6 @@
 global using DRN.Framework.SharedKernel;
 global using DRN.Framework.Utils.DependencyInjection;
+global using DRN.Nexus.Hosted.Helpers;
+global using DRN.Nexus.Hosted.Helpers.EndpointFor;
 global using Microsoft.AspNetCore.Authorization;
 global using Microsoft.AspNetCore.Mvc;

--- a/DRN.Nexus.Hosted/packages.lock.json
+++ b/DRN.Nexus.Hosted/packages.lock.json
@@ -216,8 +216,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -364,7 +364,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"

--- a/DRN.Test.Analyzer/DRN.Test.Analyzer.csproj
+++ b/DRN.Test.Analyzer/DRN.Test.Analyzer.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     </ItemGroup>
 
 </Project>

--- a/DRN.Test.Analyzer/packages.lock.json
+++ b/DRN.Test.Analyzer/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.0, 5.0.0]",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.9.0, )",
+        "resolved": "5.9.0",
+        "contentHash": "7JGDA0UT1+h7k9ZcA3rF4eFC8+QPq1xyYaXxag4p8r/zzPurEJxvdi7aM+MRL/SfP7XADXpWF/pl/eUYXOq/ww==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17",
+          "Microsoft.CodeAnalysis.Common": "[5.9.0]"
         }
       },
       "xunit.v3.mtp-v2": {
@@ -52,8 +52,8 @@
       },
       "AwesomeAssertions": {
         "type": "Transitive",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "Blake3.Native": {
         "type": "Transitive",
@@ -221,15 +221,15 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.11.0",
-        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+        "resolved": "5.9.0-1.26328.17",
+        "contentHash": "HP9NNk8ZjOSI2hgOyXnQg+kv7/X837Vr2nAlXiGAtqtYnYKjRRa1UmQFr8KFs5ynGYKqfbb8zB9APoWjiAGdMg=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.9.0",
+        "contentHash": "IYaIaUWdIx539AReKZOBEqTskFusZfCh/wFSPilDvCn5Say8MegLw2LONcSIcVy+v3Gzv53qYBspgvBGSErfbQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17"
         }
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
@@ -763,8 +763,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -1043,7 +1043,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"
@@ -1060,7 +1060,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[5.0.0-rc.1, )",
           "AutoFixture.Xunit3": "[5.0.0-rc.1, )",
-          "AwesomeAssertions": "[9.5.0, )",
+          "AwesomeAssertions": "[9.6.0, )",
           "DRN.Framework.EntityFramework": "[1.0.0, )",
           "DRN.Framework.Hosting": "[1.0.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.11, )",

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -459,7 +459,7 @@ public class ApplicationContextTests
         _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
         await context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<SampleProgram>();
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
 
         // Call Nexus via configured address (e.g. localhost:5988 or nexus)
         var appSettings = context.GetRequiredService<IAppSettings>();
@@ -498,7 +498,7 @@ public class ApplicationContextTests
         appSettings.NexusAppSettings.NexusAddress.Should().Be("custom-nexus-host");
 
         // RouterHandler can route to Nexus using configured address
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
         var forecasts = await client.GetFromJsonAsync<WeatherForecast[]>($"http://custom-nexus-host/{endpoint?.TrimStart('/')}");
         forecasts.Should().NotBeNull();
@@ -524,7 +524,7 @@ public class ApplicationContextTests
 
         _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
 
         // Valid segment matches route successfully
@@ -576,7 +576,7 @@ public class ApplicationContextTests
 
         context.ApplicationContext.MapAddress<NexusProgram>("weather-service");
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
         var forecasts = await client.GetFromJsonAsync<WeatherForecast[]>($"http://weather-service/{endpoint?.TrimStart('/')}");
         forecasts.Should().NotBeNull();
@@ -606,7 +606,7 @@ public class ApplicationContextTests
         _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
         _ = await context.ApplicationContext.CreateClientAsync<SampleProgram>();
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         Func<Task> call = () => client.GetAsync("http://unmapped-unknown-service/api/test");
 
         var ex = await call.Should().ThrowAsync<InvalidOperationException>();
@@ -621,7 +621,7 @@ public class ApplicationContextTests
     {
         _ = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("[::1]:5999");
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
 
         // Route via bracketed IPv6 + port
@@ -641,7 +641,7 @@ public class ApplicationContextTests
     {
         _ = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("http://nexus:80");
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         Func<Task> callUnrelatedHttp = () => client.GetAsync("http://unrelated-domain/api/test");
         Func<Task> callUnrelatedHttps = () => client.GetAsync("https://unrelated-domain/api/test");
 
@@ -678,7 +678,7 @@ public class ApplicationContextTests
         _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
         context.ApplicationContext.MapAddress<NexusProgram>("weather-alias");
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
         var forecasts1 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://weather-alias/{endpoint?.TrimStart('/')}");
         forecasts1.Should().NotBeNull();
@@ -731,7 +731,7 @@ public class ApplicationContextTests
         _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
         context.ApplicationContext.MapAddress<NexusProgram>("https://custom-nexus-host:5988/api/v1");
 
-        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler, disposeHandler: false);
         var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
         var forecasts = await client.GetFromJsonAsync<WeatherForecast[]>($"http://custom-nexus-host:5988/{endpoint?.TrimStart('/')}");
         forecasts.Should().NotBeNull();

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -519,6 +519,7 @@ public class ApplicationContextTests
         context.AddToConfiguration("ExternalNexusAddress", "http://external-nexus-address");
         context.AddToConfiguration("ExternalPaymentUrl", "http://external-payment-url");
         context.AddToConfiguration("ExternalNexusSettings:ServiceUrl", "http://external-nexus-service-url");
+        context.AddToConfiguration("Nexus:ExternalPaymentUrl", "http://nested-external-payment-url");
         // 5. Non-address key matching short name (should NOT match)
         context.AddToConfiguration("Nexus:Name", "ignored-value");
 
@@ -552,6 +553,10 @@ public class ApplicationContextTests
         Func<Task> callSettings = () => client.GetAsync("http://external-nexus-service-url/api/test");
         await callSettings.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*No application registered in ApplicationContext matches host 'external-nexus-service-url'*");
+
+        Func<Task> callNestedPayment = () => client.GetAsync("http://nested-external-payment-url/api/test");
+        await callNestedPayment.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No application registered in ApplicationContext matches host 'nested-external-payment-url'*");
     }
 
     [Theory]

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -697,31 +697,21 @@ public class ApplicationContextTests
     [DataInline]
     public async Task ApplicationContext_Overload_Compatibility_Should_Resolve_Without_Ambiguity(DrnTestContext context)
     {
-        // Parameterless
-        var client1 = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
-        client1.Should().NotBeNull();
+        // Execute one runtime creation to verify baseline pipeline functionality
+        var client = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        client.Should().NotBeNull();
 
-        // Positional null without naming parameter
-        var client2 = await context.ApplicationContext.CreateClientAsync<NexusProgram>(null);
-        client2.Should().NotBeNull();
-
-        var client3 = await context.ApplicationContext.CreateClientAsync<NexusProgram>(null, null);
-        client3.Should().NotBeNull();
-
-        // Service name overload
-        var client4 = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("nexus-overload-test");
-        client4.Should().NotBeNull();
-
-        // Positional null on CreateApplication and CreateApplicationAndBindDependenciesAsync
-        var app1 = context.ApplicationContext.CreateApplication<TemporaryLifecycleProgram>(null);
-        app1.Should().NotBeNull();
-
-        var app2 = await context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<TemporaryLifecycleProgram>(null);
-        app2.Should().NotBeNull();
-
-        // Public constructor on DrnWebApplicationFactory
-        using var customFactory = new DrnWebApplicationFactory<TemporaryLifecycleProgram>(context, temporary: true);
-        customFactory.Should().NotBeNull();
+        // Compile-time overload resolution checks for remaining call shapes without starting extra test servers
+        Action compileTimeOverloadCheck = () =>
+        {
+            _ = context.ApplicationContext.CreateClientAsync<NexusProgram>(null);
+            _ = context.ApplicationContext.CreateClientAsync<NexusProgram>(null, null);
+            _ = context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("nexus-overload-test");
+            _ = context.ApplicationContext.CreateApplication<TemporaryLifecycleProgram>(null);
+            _ = context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<TemporaryLifecycleProgram>(null);
+            _ = new DrnWebApplicationFactory<TemporaryLifecycleProgram>(context, temporary: true);
+        };
+        compileTimeOverloadCheck.Should().NotBeNull();
     }
 
     [Theory]

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -188,7 +188,8 @@ public class ApplicationContextTests
         // ApplicationContext owns only the parent factory. Model nested cleanup explicitly so this test covers
         // its retry contract without depending on WebApplicationFactory's internal derived-factory traversal.
         var factory = new ParentApplicationFactoryWithDerivedDisposalFailure(disposalOrder);
-        context.ApplicationContext.UseApplicationFactory(factory);
+        context.ApplicationContext.UseApplicationFactory<TemporaryLifecycleProgram>(factory);
+        context.ApplicationContext.GetCreatedApplication<TemporaryLifecycleProgram>().Should().BeNull();
 
         var firstDispose = () => context.ApplicationContext.Dispose();
         var exception = firstDispose.Should().Throw<Exception>().Which;
@@ -240,7 +241,7 @@ public class ApplicationContextTests
         _ = context.GetRequiredService<ContextOwnedDisposalTracker>();
 
         var factory = new RepeatedApplicationFactoryDisposeFailure(disposalOrder);
-        context.ApplicationContext.UseApplicationFactory(factory);
+        context.ApplicationContext.UseApplicationFactory<TemporaryLifecycleProgram>(factory);
 
         var dispose = context.Dispose;
 

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -1,11 +1,11 @@
 using System.Net.Http.Json;
 using DRN.Framework.Utils.Models.Sample;
+using DRN.Nexus.Hosted;
 using DRN.Test.Utils.Hosting;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -15,6 +15,9 @@ using Sample.Hosted;
 using Sample.Hosted.Filters;
 using Sample.Hosted.Helpers;
 using Sample.Infra.QA;
+using NexusGet = DRN.Nexus.Hosted.Helpers.Get;
+// ReSharper disable AccessToDisposedClosure
+// ReSharper disable ShortLivedHttpClient
 
 namespace DRN.Test.Integration.Tests.Framework.Testing;
 
@@ -23,10 +26,10 @@ public class ApplicationContextTests
     [Fact]
     public void ApplicationContext_Should_Resolve_Active_Xunit_Output_Helper()
     {
-        var ambientOutputHelper = Xunit.TestContext.Current.TestOutputHelper;
+        var ambientOutputHelper = TestContext.Current.TestOutputHelper;
 
         ambientOutputHelper.Should().NotBeNull();
-        InvokeOutputHelperResolver().Should().BeSameAs(ambientOutputHelper);
+        ApplicationContext.ResolveOutputHelper(debuggerOnly: false).Should().BeSameAs(ambientOutputHelper);
     }
 
     [Fact]
@@ -34,7 +37,7 @@ public class ApplicationContextTests
     {
         var suppliedOutputHelper = Substitute.For<ITestOutputHelper>();
 
-        InvokeOutputHelperResolver(suppliedOutputHelper).Should().BeSameAs(suppliedOutputHelper);
+        ApplicationContext.ResolveOutputHelper(suppliedOutputHelper, debuggerOnly: false).Should().BeSameAs(suppliedOutputHelper);
     }
 
     [Fact]
@@ -42,7 +45,7 @@ public class ApplicationContextTests
     {
         Task<ITestOutputHelper?> resolutionTask;
         using (ExecutionContext.SuppressFlow())
-            resolutionTask = Task.Run(() => InvokeOutputHelperResolver());
+            resolutionTask = Task.Run(() => ApplicationContext.ResolveOutputHelper(debuggerOnly: false));
 
         var resolvedOutputHelper = await resolutionTask;
         resolvedOutputHelper.Should().BeNull();
@@ -58,7 +61,7 @@ public class ApplicationContextTests
         var outputHelper = Substitute.For<ITestOutputHelper>();
 
         var firstApplication =
-            InvokeCreateApplicationCore<TemporaryLifecycleProgram>(context.ApplicationContext, outputHelper);
+            context.ApplicationContext.CreateApplicationCore<TemporaryLifecycleProgram>(outputHelper);
         _ = firstApplication.Server;
         firstApplication.Services.GetRequiredService<ILogger<ApplicationContextTests>>()
             .LogCritical(firstApplicationMessage);
@@ -67,7 +70,7 @@ public class ApplicationContextTests
             Arg.Is<string>(message => message != null && message.Contains(firstApplicationMessage, StringComparison.Ordinal)));
 
         var secondApplication =
-            InvokeCreateApplicationCore<TemporaryLifecycleProgram>(context.ApplicationContext, null);
+            context.ApplicationContext.CreateApplicationCore<TemporaryLifecycleProgram>(null);
         _ = secondApplication.Server;
         secondApplication.Services.GetRequiredService<ILogger<ApplicationContextTests>>()
             .LogCritical(secondApplicationMessage);
@@ -136,7 +139,7 @@ public class ApplicationContextTests
         _ = application.Services.GetRequiredService<ApplicationOwnedDisposalTracker>();
         hostedService.FailAllStops();
 
-        var dispose = () => context.Dispose();
+        var dispose = context.Dispose;
 
         var exception = dispose.Should().Throw<AggregateException>().Which;
         exception.ToString().Should().Contain(StopFailureHostedService.StopFailureMessage);
@@ -239,7 +242,7 @@ public class ApplicationContextTests
         var factory = new RepeatedApplicationFactoryDisposeFailure(disposalOrder);
         context.ApplicationContext.UseApplicationFactory(factory);
 
-        var dispose = () => context.Dispose();
+        var dispose = context.Dispose;
 
         var exception = dispose.Should().Throw<AggregateException>().Which;
         var errors = exception.Flatten().InnerExceptions;
@@ -359,7 +362,7 @@ public class ApplicationContextTests
         var hostBuilder = Substitute.For<IHostBuilder>();
         hostBuilder.Properties.Returns(new Dictionary<object, object>());
         hostBuilder.Build().Returns(host);
-        using var factory = new ExposedDrnWebApplicationFactory(context);
+        await using var factory = new ExposedDrnWebApplicationFactory(context);
         factory.UseKestrel(0);
         var failureSafeHost = factory.CreateHostForTest(hostBuilder);
         Func<Task> stop = () => failureSafeHost.StopAsync();
@@ -428,11 +431,253 @@ public class ApplicationContextTests
         appSettingsFromDrnTestContext.GetValue("PhilosophicalRazor", "").Should().Be(philosophicalRazor);
     }
 
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Should_Host_Multiple_Concurrent_Applications(DrnTestContext context)
+    {
+        var nexusClient = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        var sampleClient = await context.ApplicationContext.CreateClientAsync<SampleProgram>();
+
+        context.ApplicationContext.GetCreatedApplication<NexusProgram>().Should().NotBeNull();
+        context.ApplicationContext.GetCreatedApplication<SampleProgram>().Should().NotBeNull();
+        context.ApplicationContext.GetCreatedApplications().Should().HaveCount(2);
+
+        var nexusForecasts = await nexusClient.GetFromJsonAsync<WeatherForecast[]>(NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern);
+        nexusForecasts.Should().NotBeNull();
+        nexusForecasts.Length.Should().BePositive();
+
+        var sampleForecasts = await sampleClient.GetFromJsonAsync<WeatherForecast[]>(Get.Endpoint.Sample.WeatherForecast.Get.RoutePattern);
+        sampleForecasts.Should().NotBeNull();
+        sampleForecasts.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Should_Route_Requests_Across_Applications_Via_RouterHandler(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        await context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<SampleProgram>();
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+
+        // Call Nexus via configured address (e.g. localhost:5988 or nexus)
+        var appSettings = context.GetRequiredService<IAppSettings>();
+        var nexusEndpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var nexusUri = $"http://{appSettings.NexusAppSettings.NexusAddress}/{nexusEndpoint?.TrimStart('/')}";
+        var nexusForecasts = await client.GetFromJsonAsync<WeatherForecast[]>(nexusUri);
+        nexusForecasts.Should().NotBeNull();
+        nexusForecasts.Length.Should().BePositive();
+
+        // Call Sample via sample hostname
+        var sampleEndpoint = Get.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var sampleUri = $"http://sample/{sampleEndpoint?.TrimStart('/')}";
+        var sampleForecasts = await client.GetFromJsonAsync<WeatherForecast[]>(sampleUri);
+        sampleForecasts.Should().NotBeNull();
+        sampleForecasts.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Should_Route_To_Configured_Custom_Nexus_Address(DrnTestContext context)
+    {
+        var customNexusSettings = new NexusAppSettings
+        {
+            AppId = 7,
+            AppInstanceId = 14,
+            NexusAddress = "custom-nexus-host"
+        };
+
+        context.AddToConfiguration(new { NexusAppSettings = customNexusSettings });
+        var nexusClient = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        nexusClient.Should().NotBeNull();
+
+        var appSettings = context.GetRequiredService<IAppSettings>();
+        appSettings.NexusAppSettings.AppId.Should().Be(7);
+        appSettings.NexusAppSettings.AppInstanceId.Should().Be(14);
+        appSettings.NexusAppSettings.NexusAddress.Should().Be("custom-nexus-host");
+
+        // RouterHandler can route to Nexus using configured address
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var forecasts = await client.GetFromJsonAsync<WeatherForecast[]>($"http://custom-nexus-host/{endpoint?.TrimStart('/')}");
+        forecasts.Should().NotBeNull();
+        forecasts.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Should_Support_MultiHop_Chained_Applications(DrnTestContext context)
+    {
+        // Setup 3 chained apps: Node A -> Node B -> Node C with service names assigned at creation
+        _ = await context.ApplicationContext.CreateClientForServiceAsync<ChainedNodeCProgram>(ChainedNodeCProgram.NodeName);
+        _ = await context.ApplicationContext.CreateClientForServiceAsync<ChainedNodeBProgram>(ChainedNodeBProgram.NodeName);
+        var nodeAClient = await context.ApplicationContext.CreateClientForServiceAsync<ChainedNodeAProgram>(ChainedNodeAProgram.NodeName);
+
+        // Call Node A -> Node A calls Node B -> Node B calls Node C -> Node C returns "C" -> Node B returns "B -> C" -> Node A returns "A -> B -> C"
+        var response = await nodeAClient.GetStringAsync("/api/chain/start");
+        response.Should().Contain("A -> B -> C");
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Should_Support_Explicit_MapAddress(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+
+        context.ApplicationContext.MapAddress<NexusProgram>("weather-service");
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var forecasts = await client.GetFromJsonAsync<WeatherForecast[]>($"http://weather-service/{endpoint?.TrimStart('/')}");
+        forecasts.Should().NotBeNull();
+        forecasts.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Should_Support_Bidirectional_Service_Communication(DrnTestContext context)
+    {
+        var node1Client = await context.ApplicationContext.CreateClientForServiceAsync<BidirectionalNode1Program>(BidirectionalNode1Program.NodeName);
+        var node2Client = await context.ApplicationContext.CreateClientForServiceAsync<BidirectionalNode2Program>(BidirectionalNode2Program.NodeName);
+
+        // Node 1 calls Node 2
+        var node1Response = await node1Client.GetStringAsync("/api/node1/ping");
+        node1Response.Should().Contain("1-ping(2-pong)");
+
+        // Node 2 calls Node 1
+        var node2Response = await node2Client.GetStringAsync("/api/node2/ping");
+        node2Response.Should().Contain("2-ping(1-pong)");
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_RouterHandler_Should_Throw_Detailed_Exception_On_Unmapped_Host(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        _ = await context.ApplicationContext.CreateClientAsync<SampleProgram>();
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        Func<Task> call = () => client.GetAsync("http://unmapped-unknown-service/api/test");
+
+        var ex = await call.Should().ThrowAsync<InvalidOperationException>();
+        ex.WithMessage("*No application registered in ApplicationContext matches host 'unmapped-unknown-service'*")
+            .WithMessage("*Registered addresses:*")
+            .WithMessage("*Registered applications:*");
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_RouterHandler_Should_Route_IPv6_Addresses_And_Ports(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("[::1]:5999");
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+
+        // Route via bracketed IPv6 + port
+        var forecasts1 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://[::1]:5999/{endpoint?.TrimStart('/')}");
+        forecasts1.Should().NotBeNull();
+        forecasts1.Length.Should().BePositive();
+
+        // Route via port alone
+        var forecasts2 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://localhost:5999/{endpoint?.TrimStart('/')}");
+        forecasts2.Should().NotBeNull();
+        forecasts2.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Replacing_One_Application_Should_Not_Disrupt_Remaining_Application_Routing(DrnTestContext context)
+    {
+        // 1. Create two independent nodes
+        var node1Client = await context.ApplicationContext.CreateClientForServiceAsync<BidirectionalNode1Program>(BidirectionalNode1Program.NodeName);
+        _ = await context.ApplicationContext.CreateClientForServiceAsync<BidirectionalNode2Program>(BidirectionalNode2Program.NodeName);
+
+        // Verify initial routing from node-1 to node-2
+        var initialResponse = await node1Client.GetStringAsync("/api/node1/ping");
+        initialResponse.Should().Contain("1-ping(2-pong)");
+
+        // 2. Replace node-1 (recreation disposes the old node-1 application)
+        var newNode1Client = await context.ApplicationContext.CreateClientForServiceAsync<BidirectionalNode1Program>(BidirectionalNode1Program.NodeName);
+
+        // 3. Verify node-2 is still routable from the new node-1 instance and router handler is intact
+        var postReplacementResponse = await newNode1Client.GetStringAsync("/api/node1/ping");
+        postReplacementResponse.Should().Contain("1-ping(2-pong)");
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_MapAddress_Recreated_Application_Should_Route_To_New_Instance(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        context.ApplicationContext.MapAddress<NexusProgram>("weather-alias");
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var forecasts1 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://weather-alias/{endpoint?.TrimStart('/')}");
+        forecasts1.Should().NotBeNull();
+        forecasts1.Length.Should().BePositive();
+
+        // Recreate NexusProgram (disposes old factory and registers new one)
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+
+        // Mapped address should resolve to the newly registered instance without errors
+        var forecasts2 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://weather-alias/{endpoint?.TrimStart('/')}");
+        forecasts2.Should().NotBeNull();
+        forecasts2.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_Overload_Compatibility_Should_Resolve_Without_Ambiguity(DrnTestContext context)
+    {
+        // Parameterless
+        var client1 = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        client1.Should().NotBeNull();
+
+        // Positional null without naming parameter
+        var client2 = await context.ApplicationContext.CreateClientAsync<NexusProgram>(null);
+        client2.Should().NotBeNull();
+
+        var client3 = await context.ApplicationContext.CreateClientAsync<NexusProgram>(null, null);
+        client3.Should().NotBeNull();
+
+        // Service name overload
+        var client4 = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("nexus-overload-test");
+        client4.Should().NotBeNull();
+
+        // Positional null on CreateApplication and CreateApplicationAndBindDependenciesAsync
+        var app1 = context.ApplicationContext.CreateApplication<TemporaryLifecycleProgram>(null);
+        app1.Should().NotBeNull();
+
+        var app2 = await context.ApplicationContext.CreateApplicationAndBindDependenciesAsync<TemporaryLifecycleProgram>(null);
+        app2.Should().NotBeNull();
+
+        // Public constructor on DrnWebApplicationFactory
+        using var customFactory = new DrnWebApplicationFactory<TemporaryLifecycleProgram>(context, temporary: true);
+        customFactory.Should().NotBeNull();
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task ApplicationContext_MapAddress_With_Url_Path_Should_Route_To_Authority(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        context.ApplicationContext.MapAddress<NexusProgram>("https://custom-nexus-host:5988/api/v1");
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var forecasts = await client.GetFromJsonAsync<WeatherForecast[]>($"http://custom-nexus-host:5988/{endpoint?.TrimStart('/')}");
+        forecasts.Should().NotBeNull();
+        forecasts.Length.Should().BePositive();
+    }
+
     private sealed class ContextOwnedDisposalTracker(List<string> disposalOrder) : IDisposable
     {
         public void Dispose() => disposalOrder.Add("context");
     }
 
+    // ReSharper disable once NotAccessedPositionalProperty.Local
     private sealed record HostConfiguratorRegistration(string Source);
 
     private sealed class CallerLoggingProvider : ILoggerProvider
@@ -491,7 +736,7 @@ public class ApplicationContextTests
     private sealed class StopFailureHostedService(List<string> disposalOrder) : IHostedService
     {
         public const string StopFailureMessage = "Application stop failure.";
-        private readonly object _sync = new();
+        private readonly Lock _sync = new();
         private bool _failAllStops;
         private bool _failureRecorded;
 
@@ -579,26 +824,5 @@ public class ApplicationContextTests
         : DrnWebApplicationFactory<TemporaryLifecycleProgram>(context, true)
     {
         public IHost CreateHostForTest(IHostBuilder builder) => CreateHost(builder);
-    }
-
-    private static ITestOutputHelper? InvokeOutputHelperResolver(ITestOutputHelper? supplied = null)
-    {
-        var resolver = typeof(ApplicationContext).GetMethod(
-            "ResolveOutputHelper",
-            BindingFlags.Static | BindingFlags.NonPublic)!;
-
-        return (ITestOutputHelper?)resolver.Invoke(null, [supplied, false]);
-    }
-
-    private static WebApplicationFactory<TEntryPoint> InvokeCreateApplicationCore<TEntryPoint>(
-        ApplicationContext context,
-        ITestOutputHelper? outputHelper)
-        where TEntryPoint : class
-    {
-        var factory = typeof(ApplicationContext)
-            .GetMethod("CreateApplicationCore", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .MakeGenericMethod(typeof(TEntryPoint));
-
-        return (WebApplicationFactory<TEntryPoint>)factory.Invoke(context, [outputHelper, null])!;
     }
 }

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -636,6 +636,22 @@ public class ApplicationContextTests
 
     [Theory]
     [DataInline]
+    public async Task ApplicationContext_RouterHandler_Should_Not_Route_Unrelated_Host_When_Default_Port_Is_Registered(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientForServiceAsync<NexusProgram>("http://nexus:80");
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        Func<Task> callUnrelatedHttp = () => client.GetAsync("http://unrelated-domain/api/test");
+        Func<Task> callUnrelatedHttps = () => client.GetAsync("https://unrelated-domain/api/test");
+
+        await callUnrelatedHttp.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No application registered in ApplicationContext matches host 'unrelated-domain'*");
+        await callUnrelatedHttps.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No application registered in ApplicationContext matches host 'unrelated-domain'*");
+    }
+
+    [Theory]
+    [DataInline]
     public async Task ApplicationContext_Replacing_One_Application_Should_Not_Disrupt_Remaining_Application_Routing(DrnTestContext context)
     {
         // 1. Create two independent nodes

--- a/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/ApplicationContextTests.cs
@@ -506,6 +506,55 @@ public class ApplicationContextTests
 
     [Theory]
     [DataInline]
+    public async Task ApplicationContext_Should_Discover_Addresses_Only_From_Matching_Key_Segments(DrnTestContext context)
+    {
+        // 1. Exact short-name segment match in hierarchical key
+        context.AddToConfiguration("Services:Nexus:Url", "http://nexus-segment-url");
+        // 2. Exact type-name segment match
+        context.AddToConfiguration("NexusProgram:Address", "http://nexus-program-address");
+        // 3. Suffix on short-name (NexusAddress)
+        context.AddToConfiguration("Custom:NexusAddress", "http://nexus-suffix-address");
+        // 4. Substring in segment (should NOT match)
+        context.AddToConfiguration("ExternalNexusAddress", "http://external-nexus-address");
+        context.AddToConfiguration("ExternalPaymentUrl", "http://external-payment-url");
+        context.AddToConfiguration("ExternalNexusSettings:ServiceUrl", "http://external-nexus-service-url");
+        // 5. Non-address key matching short name (should NOT match)
+        context.AddToConfiguration("Nexus:Name", "ignored-value");
+
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+
+        using var client = new HttpClient(context.ApplicationContext.RouterHandler);
+        var endpoint = NexusGet.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+
+        // Valid segment matches route successfully
+        var r1 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://nexus-segment-url/{endpoint?.TrimStart('/')}");
+        r1.Should().NotBeNull();
+        r1.Length.Should().BePositive();
+
+        var r2 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://nexus-program-address/{endpoint?.TrimStart('/')}");
+        r2.Should().NotBeNull();
+        r2.Length.Should().BePositive();
+
+        var r3 = await client.GetFromJsonAsync<WeatherForecast[]>($"http://nexus-suffix-address/{endpoint?.TrimStart('/')}");
+        r3.Should().NotBeNull();
+        r3.Length.Should().BePositive();
+
+        // Substring / non-segment matches are not registered and throw unmapped host
+        Func<Task> callExternal = () => client.GetAsync("http://external-nexus-address/api/test");
+        await callExternal.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No application registered in ApplicationContext matches host 'external-nexus-address'*");
+
+        Func<Task> callPayment = () => client.GetAsync("http://external-payment-url/api/test");
+        await callPayment.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No application registered in ApplicationContext matches host 'external-payment-url'*");
+
+        Func<Task> callSettings = () => client.GetAsync("http://external-nexus-service-url/api/test");
+        await callSettings.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No application registered in ApplicationContext matches host 'external-nexus-service-url'*");
+    }
+
+    [Theory]
+    [DataInline]
     public async Task ApplicationContext_Should_Support_MultiHop_Chained_Applications(DrnTestContext context)
     {
         // Setup 3 chained apps: Node A -> Node B -> Node C with service names assigned at creation

--- a/DRN.Test.Integration/Tests/Framework/Testing/DataAttributes/DataAttributeMetadataIntegrationTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Testing/DataAttributes/DataAttributeMetadataIntegrationTests.cs
@@ -29,7 +29,7 @@ public class DataAttributeMetadataIntegrationTests
         };
         var testMethod = typeof(DataAttributeMetadataIntegrationTests).GetMethod(
             nameof(MetadataContextTarget),
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+            BindingFlag.StaticNonPublic)!;
         await using var disposalTracker = new DisposalTracker();
 
         var row = (await attribute.GetData(testMethod, disposalTracker)).Single();

--- a/DRN.Test.Integration/Tests/Nexus/Controller/StatusControllerTests.cs
+++ b/DRN.Test.Integration/Tests/Nexus/Controller/StatusControllerTests.cs
@@ -14,7 +14,7 @@ public class StatusControllerTests
     {
         var client = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
         var user = await AuthenticationHelper<NexusProgram>.AuthenticateClientAsync(client);
-        var status = await client.GetFromJsonAsync<ConfigurationDebugViewSummary>(Get.Endpoint.Status.Status.RoutePattern);
+        var status = await client.GetFromJsonAsync<ConfigurationDebugViewSummary>(Get.Endpoint.Sample.Status.Status.RoutePattern);
         var programName = typeof(NexusProgram).GetAssemblyName();
 
         status?.ApplicationName.Should().Be(programName);

--- a/DRN.Test.Integration/Tests/Nexus/Controller/WeatherForecastControllerTests.cs
+++ b/DRN.Test.Integration/Tests/Nexus/Controller/WeatherForecastControllerTests.cs
@@ -14,7 +14,7 @@ public class WeatherForecastControllerTests
     public async Task WeatherForecastController_Should_Return_Forecasts(DrnTestContext context)
     {
         var client = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
-        var weatherEndpoint = Get.Endpoint.WeatherForecast.Get.RoutePattern;
+        var weatherEndpoint = Get.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
         var sampleForecasts = await client.GetFromJsonAsync<WeatherForecast[]>(weatherEndpoint);
 
         sampleForecasts!.Length.Should().BePositive();
@@ -25,7 +25,7 @@ public class WeatherForecastControllerTests
     public async Task PrivateAction_Should_Not_Allow_Unauthorized(DrnTestContext context)
     {
         var client = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
-        var status = await client.GetAsync(Get.Endpoint.WeatherForecast.Private.RoutePattern);
+        var status = await client.GetAsync(Get.Endpoint.Sample.WeatherForecast.Private.RoutePattern);
 
         status.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -37,7 +37,7 @@ public class WeatherForecastControllerTests
         var client = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
         var user = await AuthenticationHelper<NexusProgram>.AuthenticateClientAsync(client);
 
-        var authorized = await client.GetStringAsync(Get.Endpoint.WeatherForecast.Private.RoutePattern);
+        var authorized = await client.GetStringAsync(Get.Endpoint.Sample.WeatherForecast.Private.RoutePattern);
         authorized.Should().Be("authorized");
     }
 }

--- a/DRN.Test.Integration/Tests/Sample/Controller/Sample/WeatherForecastControllerTests.cs
+++ b/DRN.Test.Integration/Tests/Sample/Controller/Sample/WeatherForecastControllerTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
+using DRN.Framework.Hosting.Nexus;
 using DRN.Framework.Utils.Models.Sample;
+using DRN.Nexus.Hosted;
 using Sample.Hosted;
 using Sample.Hosted.Helpers;
 
@@ -17,7 +19,7 @@ public class WeatherForecastControllerTests
         var sampleForecasts = await client.GetFromJsonAsync<WeatherForecast[]>(weatherEndpoint);
         var appSettings = context.GetRequiredService<IAppSettings>();
 
-        context.FlurlHttpTest.ForCallsTo($"*{appSettings.NexusAppSettings.NexusAddress}/WeatherForecast").RespondWithJson(sampleForecasts);
+        context.FlurlHttpTest.ForCallsTo($"*{appSettings.NexusAppSettings.NexusAddress}/{NexusEndpoints.WeatherForecast}").RespondWithJson(sampleForecasts);
 
         var nexusWeatherEndpoint = Get.Endpoint.Sample.WeatherForecast.GetNexusWeatherForecasts.RoutePattern;
         var nexusForecasts = await client.GetFromJsonAsync<WeatherForecast[]>(nexusWeatherEndpoint);
@@ -26,11 +28,30 @@ public class WeatherForecastControllerTests
 
     [Theory]
     [DataInline]
+    public async Task WeatherForecastController_Should_Return_Nexus_Forecasts_From_Hosted_Nexus(DrnTestContext context)
+    {
+        _ = await context.ApplicationContext.CreateClientAsync<NexusProgram>();
+        var sampleClient = await context.ApplicationContext.CreateClientAsync<SampleProgram>();
+
+        var sampleWeatherEndpoint = Get.Endpoint.Sample.WeatherForecast.Get.RoutePattern;
+        var sampleForecasts = await sampleClient.GetFromJsonAsync<WeatherForecast[]>(sampleWeatherEndpoint);
+        sampleForecasts.Should().NotBeNull();
+        sampleForecasts.Length.Should().BePositive();
+
+        var nexusWeatherEndpoint = Get.Endpoint.Sample.WeatherForecast.GetNexusWeatherForecasts.RoutePattern;
+        var nexusForecasts = await sampleClient.GetFromJsonAsync<WeatherForecast[]>(nexusWeatherEndpoint);
+
+        nexusForecasts.Should().NotBeNull();
+        nexusForecasts.Length.Should().BePositive();
+    }
+
+    [Theory]
+    [DataInline]
     public async Task WeatherForecastController_Should_Return_FlurlHttpExceptionStatusCodes(DrnTestContext context)
     {
         var client = await context.ApplicationContext.CreateClientAsync<SampleProgram>();
         var appSettings = context.GetRequiredService<IAppSettings>();
-        var urlPattern = $"*{appSettings.NexusAppSettings.NexusAddress}/WeatherForecast";
+        var urlPattern = $"*{appSettings.NexusAppSettings.NexusAddress}/{NexusEndpoints.WeatherForecast}";
         var nexusWeatherEndpoint = Get.Endpoint.Sample.WeatherForecast.GetNexusWeatherForecasts.RoutePattern;
 
         context.FlurlHttpTest.ForCallsTo(urlPattern).RespondWith("", 428);

--- a/DRN.Test.Integration/packages.lock.json
+++ b/DRN.Test.Integration/packages.lock.json
@@ -42,8 +42,8 @@
       },
       "AwesomeAssertions": {
         "type": "Transitive",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "Blake3.Native": {
         "type": "Transitive",
@@ -800,8 +800,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -1109,7 +1109,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"
@@ -1123,7 +1123,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[5.0.0-rc.1, )",
           "AutoFixture.Xunit3": "[5.0.0-rc.1, )",
-          "AwesomeAssertions": "[9.5.0, )",
+          "AwesomeAssertions": "[9.6.0, )",
           "DRN.Framework.EntityFramework": "[1.0.0, )",
           "DRN.Framework.Hosting": "[1.0.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.11, )",

--- a/DRN.Test.Performance/DRN.Test.Performance.csproj
+++ b/DRN.Test.Performance/DRN.Test.Performance.csproj
@@ -9,10 +9,10 @@
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0" />
     </ItemGroup>
 

--- a/DRN.Test.Performance/packages.lock.json
+++ b/DRN.Test.Performance/packages.lock.json
@@ -22,12 +22,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.0, 5.0.0]",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.9.0, )",
+        "resolved": "5.9.0",
+        "contentHash": "7JGDA0UT1+h7k9ZcA3rF4eFC8+QPq1xyYaXxag4p8r/zzPurEJxvdi7aM+MRL/SfP7XADXpWF/pl/eUYXOq/ww==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17",
+          "Microsoft.CodeAnalysis.Common": "[5.9.0]"
         }
       },
       "xunit.v3.mtp-v2": {
@@ -70,8 +70,8 @@
       },
       "AwesomeAssertions": {
         "type": "Transitive",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
@@ -292,15 +292,15 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.11.0",
-        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+        "resolved": "5.9.0-1.26328.17",
+        "contentHash": "HP9NNk8ZjOSI2hgOyXnQg+kv7/X837Vr2nAlXiGAtqtYnYKjRRa1UmQFr8KFs5ynGYKqfbb8zB9APoWjiAGdMg=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.9.0",
+        "contentHash": "IYaIaUWdIx539AReKZOBEqTskFusZfCh/wFSPilDvCn5Say8MegLw2LONcSIcVy+v3Gzv53qYBspgvBGSErfbQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17"
         }
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
@@ -869,8 +869,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -1204,7 +1204,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"
@@ -1218,7 +1218,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[5.0.0-rc.1, )",
           "AutoFixture.Xunit3": "[5.0.0-rc.1, )",
-          "AwesomeAssertions": "[9.5.0, )",
+          "AwesomeAssertions": "[9.6.0, )",
           "DRN.Framework.EntityFramework": "[1.0.0, )",
           "DRN.Framework.Hosting": "[1.0.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.11, )",

--- a/DRN.Test.Unit/Tests/Framework/Testing/DataAttributes/DataAttributeMetadataTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Testing/DataAttributes/DataAttributeMetadataTests.cs
@@ -272,9 +272,7 @@ public class DataAttributeMetadataTests
         };
 
     private static MethodInfo GetMetadataTarget(string methodName = nameof(MetadataTarget)) =>
-        typeof(DataAttributeMetadataTests).GetMethod(
-            methodName,
-            BindingFlag.StaticNonPublic)!;
+        typeof(DataAttributeMetadataTests).GetMethod(methodName, BindingFlag.StaticNonPublic)!;
 
     private static void MetadataTarget(int value)
     {

--- a/DRN.Test.Unit/Tests/Framework/Testing/DataAttributes/DataAttributeMetadataTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Testing/DataAttributes/DataAttributeMetadataTests.cs
@@ -274,7 +274,7 @@ public class DataAttributeMetadataTests
     private static MethodInfo GetMetadataTarget(string methodName = nameof(MetadataTarget)) =>
         typeof(DataAttributeMetadataTests).GetMethod(
             methodName,
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+            BindingFlag.StaticNonPublic)!;
 
     private static void MetadataTarget(int value)
     {

--- a/DRN.Test.Unit/packages.lock.json
+++ b/DRN.Test.Unit/packages.lock.json
@@ -42,8 +42,8 @@
       },
       "AwesomeAssertions": {
         "type": "Transitive",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "Blake3.Native": {
         "type": "Transitive",
@@ -800,8 +800,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -1109,7 +1109,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"
@@ -1123,7 +1123,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[5.0.0-rc.1, )",
           "AutoFixture.Xunit3": "[5.0.0-rc.1, )",
-          "AwesomeAssertions": "[9.5.0, )",
+          "AwesomeAssertions": "[9.6.0, )",
           "DRN.Framework.EntityFramework": "[1.0.0, )",
           "DRN.Framework.Hosting": "[1.0.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.11, )",

--- a/DRN.Test.Utils/Hosting/MultiAppRoutingTestPrograms.cs
+++ b/DRN.Test.Utils/Hosting/MultiAppRoutingTestPrograms.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using DRN.Framework.Hosting.DrnProgram;
+using DRN.Framework.Utils.DependencyInjection;
+using DRN.Framework.Utils.Http;
+using DRN.Framework.Utils.Logging;
+using DRN.Framework.Utils.Settings;
+using Flurl.Http;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+
+namespace DRN.Test.Utils.Hosting;
+
+public sealed class ChainedNodeAProgram : DrnProgramBase<ChainedNodeAProgram>, IDrnProgram
+{
+    public const string NodeName = "node-a";
+
+    public static async Task Main(string[] args) => await RunAsync(args);
+
+    protected override Task AddServicesAsync(WebApplicationBuilder builder, IAppSettings appSettings, IScopedLog scopedLog)
+    {
+        builder.Services.AddServicesWithAttributes();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureMvcBuilder(IMvcBuilder mvcBuilder, IAppSettings appSettings)
+    {
+        base.ConfigureMvcBuilder(mvcBuilder, appSettings);
+        mvcBuilder.ScopeToController<ChainedNodeAController>();
+    }
+}
+
+public sealed class ChainedNodeBProgram : DrnProgramBase<ChainedNodeBProgram>, IDrnProgram
+{
+    public const string NodeName = "node-b";
+
+    public static async Task Main(string[] args) => await RunAsync(args);
+
+    protected override Task AddServicesAsync(WebApplicationBuilder builder, IAppSettings appSettings, IScopedLog scopedLog)
+    {
+        builder.Services.AddServicesWithAttributes();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureMvcBuilder(IMvcBuilder mvcBuilder, IAppSettings appSettings)
+    {
+        base.ConfigureMvcBuilder(mvcBuilder, appSettings);
+        mvcBuilder.ScopeToController<ChainedNodeBController>();
+    }
+}
+
+public sealed class ChainedNodeCProgram : DrnProgramBase<ChainedNodeCProgram>, IDrnProgram
+{
+    public const string NodeName = "node-c";
+
+    public static async Task Main(string[] args) => await RunAsync(args);
+
+    protected override Task AddServicesAsync(WebApplicationBuilder builder, IAppSettings appSettings, IScopedLog scopedLog)
+    {
+        builder.Services.AddServicesWithAttributes();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureMvcBuilder(IMvcBuilder mvcBuilder, IAppSettings appSettings)
+    {
+        base.ConfigureMvcBuilder(mvcBuilder, appSettings);
+        mvcBuilder.ScopeToController<ChainedNodeCController>();
+    }
+}
+
+public sealed class BidirectionalNode1Program : DrnProgramBase<BidirectionalNode1Program>, IDrnProgram
+{
+    public const string NodeName = "node-1";
+
+    public static async Task Main(string[] args) => await RunAsync(args);
+
+    protected override Task AddServicesAsync(WebApplicationBuilder builder, IAppSettings appSettings, IScopedLog scopedLog)
+    {
+        builder.Services.AddServicesWithAttributes();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureMvcBuilder(IMvcBuilder mvcBuilder, IAppSettings appSettings)
+    {
+        base.ConfigureMvcBuilder(mvcBuilder, appSettings);
+        mvcBuilder.ScopeToController<BidirectionalNode1Controller>();
+    }
+}
+
+public sealed class BidirectionalNode2Program : DrnProgramBase<BidirectionalNode2Program>, IDrnProgram
+{
+    public const string NodeName = "node-2";
+
+    public static async Task Main(string[] args) => await RunAsync(args);
+
+    protected override Task AddServicesAsync(WebApplicationBuilder builder, IAppSettings appSettings, IScopedLog scopedLog)
+    {
+        builder.Services.AddServicesWithAttributes();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureMvcBuilder(IMvcBuilder mvcBuilder, IAppSettings appSettings)
+    {
+        base.ConfigureMvcBuilder(mvcBuilder, appSettings);
+        mvcBuilder.ScopeToController<BidirectionalNode2Controller>();
+    }
+}
+
+internal static class MultiAppMvcBuilderExtensions
+{
+    public static IMvcBuilder ScopeToController<TController>(this IMvcBuilder mvcBuilder) where TController : ControllerBase
+    {
+        mvcBuilder.ConfigureApplicationPartManager(manager =>
+        {
+            var existing = manager.FeatureProviders.OfType<ControllerFeatureProvider>().ToList();
+            foreach (var provider in existing)
+                manager.FeatureProviders.Remove(provider);
+
+            manager.FeatureProviders.Add(new SpecificControllerFeatureProvider(typeof(TController)));
+        });
+        return mvcBuilder;
+    }
+
+    private sealed class SpecificControllerFeatureProvider(Type controllerType) : ControllerFeatureProvider
+    {
+        protected override bool IsController(TypeInfo typeInfo) => typeInfo.AsType() == controllerType;
+    }
+}
+
+[ApiController]
+[Route("api/chain")]
+public class ChainedNodeAController(IInternalRequest internalRequest) : ControllerBase
+{
+    [HttpGet("start")]
+    [AllowAnonymous]
+    public async Task<IActionResult> StartAsync()
+    {
+        var response = await internalRequest.For(ChainedNodeBProgram.NodeName).AppendPathSegment("api/chain/step").GetStringAsync();
+        return Ok($"A -> {response}");
+    }
+}
+
+[ApiController]
+[Route("api/chain")]
+public class ChainedNodeBController(IInternalRequest internalRequest) : ControllerBase
+{
+    [HttpGet("step")]
+    [AllowAnonymous]
+    public async Task<IActionResult> StepAsync()
+    {
+        var response = await internalRequest.For(ChainedNodeCProgram.NodeName).AppendPathSegment("api/chain/leaf").GetStringAsync();
+        return Ok($"B -> {response}");
+    }
+}
+
+[ApiController]
+[Route("api/chain")]
+public class ChainedNodeCController : ControllerBase
+{
+    [HttpGet("leaf")]
+    [AllowAnonymous]
+    public IActionResult Leaf() => Ok("C");
+}
+
+[ApiController]
+[Route("api/node1")]
+public class BidirectionalNode1Controller(IInternalRequest internalRequest) : ControllerBase
+{
+    [HttpGet("ping")]
+    [AllowAnonymous]
+    public async Task<IActionResult> PingAsync()
+    {
+        var response = await internalRequest.For(BidirectionalNode2Program.NodeName).AppendPathSegment("api/node2/pong").GetStringAsync();
+        return Ok($"1-ping({response})");
+    }
+
+    [HttpGet("pong")]
+    [AllowAnonymous]
+    public IActionResult Pong() => Ok("1-pong");
+}
+
+[ApiController]
+[Route("api/node2")]
+public class BidirectionalNode2Controller(IInternalRequest internalRequest) : ControllerBase
+{
+    [HttpGet("ping")]
+    [AllowAnonymous]
+    public async Task<IActionResult> PingAsync()
+    {
+        var response = await internalRequest.For(BidirectionalNode1Program.NodeName).AppendPathSegment("api/node1/pong").GetStringAsync();
+        return Ok($"2-ping({response})");
+    }
+
+    [HttpGet("pong")]
+    [AllowAnonymous]
+    public IActionResult Pong() => Ok("2-pong");
+}

--- a/DRN.Test.Utils/packages.lock.json
+++ b/DRN.Test.Utils/packages.lock.json
@@ -74,8 +74,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -134,7 +134,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"

--- a/Sample.Hosted/Helpers/EndpointFor/UserApiFor.cs
+++ b/Sample.Hosted/Helpers/EndpointFor/UserApiFor.cs
@@ -19,12 +19,15 @@ public class UserIdentityFor
     //By convention, Endpoint name should match Action name and property should have setter;
     public UserIdentityRegisterFor RegisterController { get; } = new();
     public UserIdentityLoginFor LoginController { get; } = new();
+    public SampleIdentityPasswordFor PasswordController { get; } = new();
+    public SampleIdentityManagementFor ManagementController { get; } = new();
 }
 
 public class UserIdentityLoginFor() : ControllerForBase<SampleIdentityLoginController>(UserApiFor.ControllerRouteTemplate)
 {
     //By convention, Endpoint name should match Action name and property should have setter;
     public ApiEndpoint Login { get; private set; } = null!;
+    public ApiEndpoint Refresh { get; private set; } = null!;
 }
 
 public class UserIdentityRegisterFor() : ControllerForBase<SampleIdentityRegister>(UserApiFor.ControllerRouteTemplate)
@@ -34,10 +37,26 @@ public class UserIdentityRegisterFor() : ControllerForBase<SampleIdentityRegiste
 
     //By convention, Endpoint name should match Action name and property should have setter;
     public ApiEndpoint ConfirmEmail { get; private set; } = null!;
+    public ApiEndpoint ResendConfirmationEmail { get; private set; } = null!;
 }
 
 public class ProfilePictureFor() : ControllerForBase<ProfilePictureController>(UserApiFor.ControllerRouteTemplate)
 {
     //By convention, Endpoint name should match Action name and property should have setter;
     public ApiEndpoint Get { get; private set; } = null!;
+}
+
+public class SampleIdentityPasswordFor() : ControllerForBase<SampleIdentityPasswordController>(UserApiFor.ControllerRouteTemplate)
+{
+    //By convention, Endpoint name should match Action name and property should have setter;
+    public ApiEndpoint Forgot { get; private set; } = null!;
+    public ApiEndpoint Reset { get; private set; } = null!;
+}
+
+public class SampleIdentityManagementFor() : ControllerForBase<SampleIdentityManagementController>(UserApiFor.ControllerRouteTemplate)
+{
+    //By convention, Endpoint name should match Action name and property should have setter;
+    public ApiEndpoint TwoFactorAuth { get; private set; } = null!;
+    public ApiEndpoint GetInfo { get; private set; } = null!;
+    public ApiEndpoint PostInfo { get; private set; } = null!;
 }

--- a/Sample.Hosted/packages.lock.json
+++ b/Sample.Hosted/packages.lock.json
@@ -244,8 +244,8 @@
       },
       "NLog.Targets.Network": {
         "type": "Transitive",
-        "resolved": "6.1.4",
-        "contentHash": "9JGMwZu0NZ30NO56FYQ3i4/2zzsmxWE/WMtB6WJEtzr4ixMCevzTCrslgEA3A02HeZtDJfln/+9FB6pV1ERG0Q==",
+        "resolved": "6.1.5",
+        "contentHash": "mCJgN0ghcLcMEpTnMwxDD+QbwxaqdltTwi7T6J2poykbPxhZRuu+5f3spXU2DKzh3WM9RK6weYRFji+CBGk6FA==",
         "dependencies": {
           "NLog": "6.1.4"
         }
@@ -400,7 +400,7 @@
         "type": "Project",
         "dependencies": {
           "DRN.Framework.Utils": "[1.0.0, )",
-          "NLog.Targets.Network": "[6.1.4, )",
+          "NLog.Targets.Network": "[6.1.5, )",
           "NLog.Web.AspNetCore": "[6.2.0, )",
           "NetEscapades.AspNetCore.SecurityHeaders": "[1.3.1, )",
           "Swashbuckle.AspNetCore": "[10.2.3, )"


### PR DESCRIPTION
Add ApplicationContextRouterHandler to enable in-memory HTTP routing across multiple WebApplicationFactory instances during integration tests.

- Implement ApplicationContextRouterHandler for routing by host, port, alias, and discovered configuration addresses
- Support HttpMessageHandler injection in InternalRequest and ExternalRequest
- Add multi-tier in-memory routing and address mapping integration tests
- Update package release notes, documentation, and agent skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for hosting multiple applications concurrently with in-memory HTTP routing.
  * Added custom service aliases, address mappings, IPv6 and port routing, and automatic address discovery.
  * Added reusable endpoint definitions for status, weather, authentication, password, account management, and token refresh operations.
  * Added optional request-handler integration for intercepted and in-memory HTTP calls.
* **Documentation**
  * Expanded testing and request documentation with multi-application routing examples.
* **Tests**
  * Added coverage for chained, bidirectional, mapped-address, replacement, and hosted-service scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->