### PR TITLE
Feature/hosting swagger csp

### DIFF
--- a/.agent/skills/drn-hosting/SKILL.md
+++ b/.agent/skills/drn-hosting/SKILL.md
@@ -182,6 +182,8 @@ protected override void ConfigureAuthorizationOptions(AuthorizationOptions optio
 
 ### Per-Route Security Headers
 
+Assign the validated slash-trimmed UI prefix back to `SwaggerUIOptions.RoutePrefix` so Swagger middleware and CSP selection use the same normalized path.
+
 When Swagger is enabled, its UI prefix must be nonempty after trimming slashes; validate after the consumer callback and reject null, empty, or slash-only prefixes. Prefixes such as `api-docs` are supported. Root mounts are rejected because they would apply Swagger CSP across the entire application. The response policy selector matches the complete validated prefix with segment boundaries. Reserve that subtree for `CspFor.CspPolicySwagger` (same-origin scripts and inline styles); place ordinary application pages outside it. No request marker middleware is needed. Disabled Swagger retains application policies.
 
 ```csharp

--- a/.agent/skills/drn-hosting/SKILL.md
+++ b/.agent/skills/drn-hosting/SKILL.md
@@ -182,6 +182,8 @@ protected override void ConfigureAuthorizationOptions(AuthorizationOptions optio
 
 ### Per-Route Security Headers
 
+When Swagger is enabled, its UI prefix must be nonempty after trimming slashes; validate after the consumer callback and reject null, empty, or slash-only prefixes. Prefixes such as `api-docs` are supported. Root mounts are rejected because they would apply Swagger CSP across the entire application. The response policy selector matches the complete validated prefix with segment boundaries. Reserve that subtree for `CspFor.CspPolicySwagger` (same-origin scripts and inline styles); place ordinary application pages outside it. No request marker middleware is needed. Disabled Swagger retains application policies.
+
 ```csharp
 protected override void ConfigureSecurityHeaderPolicyBuilder(SecurityHeaderPolicyBuilder builder, IServiceProvider serviceProvider, IAppSettings appSettings)
 {

--- a/DRN.Framework.EntityFramework/Context/DbContextConventions.cs
+++ b/DRN.Framework.EntityFramework/Context/DbContextConventions.cs
@@ -27,6 +27,7 @@ public static class DbContextConventions
 
     [SuppressMessage("SonarQube", "S2326", Justification = "Generic cache per context type")]
     [SuppressMessage("SonarQube", "S2743", Justification = "Generic cache per context type")]
+    [SuppressMessage("Usage", "CA2263:Prefer generic overload when type is known", Justification = "Avoid infinite recursion into generic cache entry point")]
     [SuppressMessage("ReSharper", "StaticMemberInGenericType")]
     [SuppressMessage("ReSharper", "UnusedTypeParameter")]
     private static class ContextAttributeCache<TContext>

--- a/DRN.Framework.Hosting/DrnProgram/Configurators/DrnPipelineConfigurator.cs
+++ b/DRN.Framework.Hosting/DrnProgram/Configurators/DrnPipelineConfigurator.cs
@@ -79,7 +79,7 @@ internal sealed class DrnPipelineConfigurator
         if (!options.AddSwagger) return;
 
         application.MapSwagger(options.DefaultRouteTemplate, options.ConfigureSwaggerEndpointOptions);
-        application.UseSwaggerUI(options.ConfigureSwaggerUIOptionsAction);
+        application.UseSwaggerUI(options.ConfigureSwaggerUI);
     }
 
     internal static void MapApplicationEndpoints(WebApplication application)

--- a/DRN.Framework.Hosting/DrnProgram/Configurators/DrnSecurityConfigurator.cs
+++ b/DRN.Framework.Hosting/DrnProgram/Configurators/DrnSecurityConfigurator.cs
@@ -92,7 +92,7 @@ internal static class DrnSecurityConfigurator
     }
 
     internal static void ConfigureSecurityHeaderPolicyBuilder(SecurityHeaderPolicyBuilder builder,
-        IServiceProvider serviceProvider, IAppSettings appSettings,
+        IServiceProvider serviceProvider, IAppSettings appSettings, DrnProgramSwaggerOptions swaggerOptions,
         Action<HeaderPolicyCollection, IServiceProvider, IAppSettings> configureDefaultSecurityHeaders,
         Action<CspBuilder> configureDefaultCspBase)
     {
@@ -107,6 +107,18 @@ internal static class DrnSecurityConfigurator
         });
         builder.AddPolicy(CspFor.CspPolicySelf, selfCsp);
 
+        var swaggerCsp = new HeaderPolicyCollection();
+        configureDefaultSecurityHeaders(swaggerCsp, serviceProvider, appSettings);
+        swaggerCsp.Remove("Content-Security-Policy");
+        swaggerCsp.AddContentSecurityPolicy(x =>
+        {
+            configureDefaultCspBase(x);
+            x.AddScriptSrc().Self();
+            // Swagger renders inline SVG styles. Replace the nonce directive so unsafe-inline is effective.
+            x.AddStyleSrc().Self().UnsafeInline();
+        });
+        builder.AddPolicy(CspFor.CspPolicySwagger, swaggerCsp);
+
         var inlineCspPolicy = new HeaderPolicyCollection();
         configureDefaultSecurityHeaders(inlineCspPolicy, serviceProvider, appSettings);
         inlineCspPolicy.Remove("Content-Security-Policy");
@@ -120,9 +132,9 @@ internal static class DrnSecurityConfigurator
         builder.SetPolicySelector(x =>
         {
             var context = x.HttpContext;
-            var isSwaggerPath = context.Request.Path.Value?.Contains("swagger", StringComparison.OrdinalIgnoreCase) ?? false;
-            if (isSwaggerPath)
-                return x.ConfiguredPolicies[CspFor.CspPolicySelf];
+            if (swaggerOptions.SwaggerUIPathPrefix is { } prefix &&
+                context.Request.Path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase))
+                return x.ConfiguredPolicies[CspFor.CspPolicySwagger];
 
             var policyApplied = context.Items.TryGetValue(CspFor.CspPolicyName, out var policy);
             if (!policyApplied)

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
@@ -385,7 +385,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
     /// </summary>
     /// <remarks>
     /// Base calls <see cref="ConfigureDefaultCspBase"/> and adds a script nonce. Retain nonce protection when composing
-    /// changes. Named self/inline policies replace this CSP; shared directives belong in <see cref="ConfigureDefaultCspBase"/>.
+    /// changes. Named self/inline/Swagger policies replace this CSP; shared directives belong in <see cref="ConfigureDefaultCspBase"/>.
     /// <para>References and validation tools:</para>
     /// <list type="bullet">
     /// <item><description><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#strict_csp">Strict CSP</a></description></item>
@@ -406,6 +406,7 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
     /// <remarks>
     /// Call base to retain restrictive defaults, then add only required origins. Script-source selection is applied
     /// afterward by the default or named policy; this hook supplies their common directives.
+    /// The Swagger policy also replaces style-src with self and unsafe-inline for its inline SVG styles.
     /// </remarks>
     protected virtual void ConfigureDefaultCspBase(CspBuilder builder) =>
         DrnSecurityConfigurator.ConfigureDefaultCspBase(builder);
@@ -414,11 +415,11 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
     /// Override to register additional named header policies or select policies for application-specific routes.
     /// </summary>
     /// <remarks>
-    /// Call base to retain DRN's self/inline policies and selector. Replacing the selector must also account for
+    /// Call base to retain DRN's self/inline/Swagger policies and selector. Replacing the selector must also account for
     /// Swagger and endpoint-selected policies if those behaviors are still needed.
     /// </remarks>
     protected virtual void ConfigureSecurityHeaderPolicyBuilder(SecurityHeaderPolicyBuilder builder, IServiceProvider serviceProvider, IAppSettings appSettings) =>
-        DrnSecurityConfigurator.ConfigureSecurityHeaderPolicyBuilder(builder, serviceProvider, appSettings,
+        DrnSecurityConfigurator.ConfigureSecurityHeaderPolicyBuilder(builder, serviceProvider, appSettings, DrnProgramSwaggerOptions,
             ConfigureDefaultSecurityHeaders, ConfigureDefaultCspBase);
 
     /// <summary>

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramBase.cs
@@ -117,7 +117,8 @@ public abstract class DrnProgramBase<TProgram> : DrnProgram
     /// Shared by instances of the same program type, independently of other program types.
     /// Both bootstrap and host logging use these options; avoid mutating them after startup.
     /// </remarks>
-    // ReSharper disable once StaticMemberInGenericType
+    [SuppressMessage("SonarQube", "S2743", Justification = "Per-program NLog options configuration")]
+    [SuppressMessage("ReSharper", "StaticMemberInGenericType")]
     protected static NLogAspNetCoreOptions NLogOptions { get; set; } = DrnNLogConfigurator.CreateDefaultOptions();
 
     private static LogFactory CreateLogFactory(IAppSettings appSettings) => DrnNLogConfigurator.CreateLogFactory(appSettings, NlogConfigSectionName);

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramSwaggerOptions.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramSwaggerOptions.cs
@@ -12,6 +12,18 @@ namespace DRN.Framework.Hosting.DrnProgram;
 
 public class DrnProgramSwaggerOptions
 {
+    internal PathString? SwaggerUIPathPrefix { get; private set; }
+
+    internal void ConfigureSwaggerUI(SwaggerUIOptions options)
+    {
+        ConfigureSwaggerUIOptionsAction?.Invoke(options);
+        var prefix = options.RoutePrefix?.Trim('/');
+        if (string.IsNullOrEmpty(prefix))
+            throw new ConfigurationException("Swagger UI RoutePrefix must be nonempty after trimming slashes. Root mounts are not supported.");
+
+        SwaggerUIPathPrefix = new PathString("/" + prefix);
+    }
+
     public bool AddSwagger { get; set; }
     public bool ApplyTargetServerForwardedHeadersCorrection { get; set; } = true;
     public bool AddBearerTokenSecurityRequirement { get; set; } = true;

--- a/DRN.Framework.Hosting/DrnProgram/DrnProgramSwaggerOptions.cs
+++ b/DRN.Framework.Hosting/DrnProgram/DrnProgramSwaggerOptions.cs
@@ -21,6 +21,7 @@ public class DrnProgramSwaggerOptions
         if (string.IsNullOrEmpty(prefix))
             throw new ConfigurationException("Swagger UI RoutePrefix must be nonempty after trimming slashes. Root mounts are not supported.");
 
+        options.RoutePrefix = prefix;
         SwaggerUIPathPrefix = new PathString("/" + prefix);
     }
 

--- a/DRN.Framework.Hosting/Endpoints/CspFor.cs
+++ b/DRN.Framework.Hosting/Endpoints/CspFor.cs
@@ -5,6 +5,7 @@ public class CspFor
     public const string CspPolicyName = nameof(CspPolicyName);
     public const string CspPolicySelf = nameof(CspPolicySelf);
     public const string CspPolicyInline = nameof(CspPolicyInline);
+    public const string CspPolicySwagger = nameof(CspPolicySwagger);
     
     public string SelfPolicy => CspPolicySelf;
     public string InlinePolicy => CspPolicyInline;

--- a/DRN.Framework.Hosting/HostingModule.cs
+++ b/DRN.Framework.Hosting/HostingModule.cs
@@ -17,6 +17,7 @@ public static class HostingModule
         sc.ConfigureHttpJsonOptions(jsonOptions => JsonConventions.SetJsonDefaults(jsonOptions.SerializerOptions));
         sc.AddLogging();
         sc.AddEndpointsApiExplorer();
+        sc.AddHttpContextAccessor();
 
         sc.AddServicesWithAttributes();
         if (options.AddSwagger)

--- a/DRN.Framework.Hosting/README.md
+++ b/DRN.Framework.Hosting/README.md
@@ -545,6 +545,8 @@ For example, load an application-owned analytics entry only after analytics cons
 
 ### Route-specific security headers
 
+Leading and trailing slashes are removed from the configured Swagger UI prefix before both middleware routing and CSP selection; `/docs/` becomes `docs`.
+
 When Swagger is enabled, its UI `RoutePrefix` must be nonempty after trimming slashes, for example `swagger`, `docs/swagger`, or `api-docs`. Validation runs after `ConfigureSwaggerUIOptionsAction`; a null, empty, or slash-only prefix fails startup with `ConfigurationException` because a root mount would apply Swagger CSP across the entire application. The complete configured subtree is reserved for `CspFor.CspPolicySwagger`, including application endpoints placed beneath it. Matching is case-insensitive and respects path segment boundaries. Keep ordinary application pages outside that subtree. Disabling Swagger leaves application policies unchanged.
 
 The Swagger policy allows scripts from `'self'` and styles from `'self' 'unsafe-inline'` to support inline SVG styles without changing the generated document or its caching. It replaces the shared `style-src` directive. Self/inline endpoint policies retain their nonce-based styles. Replace `CspFor.CspPolicySwagger` through `builder.AddPolicy` after calling base to customize Swagger independently; selecting that name through `CspPolicyName` does not opt unrelated endpoints into it.

--- a/DRN.Framework.Hosting/README.md
+++ b/DRN.Framework.Hosting/README.md
@@ -545,6 +545,10 @@ For example, load an application-owned analytics entry only after analytics cons
 
 ### Route-specific security headers
 
+When Swagger is enabled, its UI `RoutePrefix` must be nonempty after trimming slashes, for example `swagger`, `docs/swagger`, or `api-docs`. Validation runs after `ConfigureSwaggerUIOptionsAction`; a null, empty, or slash-only prefix fails startup with `ConfigurationException` because a root mount would apply Swagger CSP across the entire application. The complete configured subtree is reserved for `CspFor.CspPolicySwagger`, including application endpoints placed beneath it. Matching is case-insensitive and respects path segment boundaries. Keep ordinary application pages outside that subtree. Disabling Swagger leaves application policies unchanged.
+
+The Swagger policy allows scripts from `'self'` and styles from `'self' 'unsafe-inline'` to support inline SVG styles without changing the generated document or its caching. It replaces the shared `style-src` directive. Self/inline endpoint policies retain their nonce-based styles. Replace `CspFor.CspPolicySwagger` through `builder.AddPolicy` after calling base to customize Swagger independently; selecting that name through `CspPolicyName` does not opt unrelated endpoints into it.
+
 Customize security headers for specific routes by overriding `ConfigureSecurityHeaderPolicyBuilder`:
 
 ```csharp

--- a/DRN.Framework.Hosting/RELEASE-NOTES.md
+++ b/DRN.Framework.Hosting/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 ### Security
 
+*   **Swagger Prefix Normalization**: Leading and trailing slashes are removed from the UI prefix for both Swagger routing and CSP selection, preserving redirects from `/docs` and `/docs/` to the document when configured with `/docs/`.
 *   **Swagger CSP**: Added the independently replaceable `CspFor.CspPolicySwagger` policy with same-origin scripts and inline styles for Swagger SVG rendering, preserving document caching. Selection matches the validated UI prefix with path segment boundaries. Disabled Swagger retains the default CSP. Existing self/inline policies outside the Swagger subtree retain nonce-based styles.
 *   **Revocation Guidance**: Documented cookie, refresh-token, and access-token revocation limits. Existing token lifetimes and default MFA requirements are unchanged.
 *   **Authorization Audit Events**: Added challenge, forbid, and exemption events (7401–7403) for log filtering and alerts. Factor, recovery, and revocation events are not included.

--- a/DRN.Framework.Hosting/RELEASE-NOTES.md
+++ b/DRN.Framework.Hosting/RELEASE-NOTES.md
@@ -12,6 +12,7 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 ### Breaking Changes
 
+*   **Swagger UI Prefix Validation**: When enabled, Swagger UI requires a `RoutePrefix` that is nonempty after trimming slashes. Root mounts now fail startup; migrate to a non-root prefix such as `swagger`, `docs/swagger`, or `api-docs`. The configured subtree is reserved for Swagger CSP.
 *   **Authenticated UI Visibility Convention**: `authorized-only` now checks `ScopeContext.Authenticated` instead of completed MFA. Authenticated users with pending or incomplete MFA can see these elements on anonymous or MFA-exempt pages. Endpoint policies remain responsible for MFA enforcement; use `policy-only` for policy-specific visibility.
 *   **Presence-Only Visibility Markers**: Removed the `AuthorizedOnly` and `AnonymousOnly` boolean properties from their TagHelpers. Use bare `authorized-only` / `anonymous-only` attributes; presence activates filtering regardless of the value, including `"false"`. Omit the attribute to omit its filter. Both markers are removed from rendered HTML.
 *   **Policy-Scoped MFA Exemptions**: Exempt schemes must also be selected for authentication. Programmatic authorization without an HTTP policy context no longer uses scheme exemptions.
@@ -23,6 +24,7 @@ Not every version includes changes, features or bug fixes. This project can incr
 
 ### Security
 
+*   **Swagger CSP**: Added the independently replaceable `CspFor.CspPolicySwagger` policy with same-origin scripts and inline styles for Swagger SVG rendering, preserving document caching. Selection matches the validated UI prefix with path segment boundaries. Disabled Swagger retains the default CSP. Existing self/inline policies outside the Swagger subtree retain nonce-based styles.
 *   **Revocation Guidance**: Documented cookie, refresh-token, and access-token revocation limits. Existing token lifetimes and default MFA requirements are unchanged.
 *   **Authorization Audit Events**: Added challenge, forbid, and exemption events (7401–7403) for log filtering and alerts. Factor, recovery, and revocation events are not included.
 *   **Reverse Proxy Trust & Forwarded Headers**: Binds `ForwardedHeaders` settings with CIDR and proxy parsing. Invalid formats throw `ConfigurationException`. Defaults trust RFC 1918 private networks and loopback with `ForwardLimit = 2`. `TrustPrivateNetworks = false` removes the private-network defaults. A nonempty `KnownIPNetworks` list replaces network defaults; `KnownProxies` adds entries without clearing existing trust.

--- a/DRN.Test.Integration/Tests/Framework/Hosting/CspIntegrationTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Hosting/CspIntegrationTests.cs
@@ -125,6 +125,35 @@ public class CspIntegrationTests
     }
 
     [Theory]
+    [DataInline("/docs", "/docs")]
+    [DataInline("/docs", "/docs/")]
+    [DataInline("docs/", "/docs")]
+    [DataInline("docs/", "/docs/")]
+    [DataInline("/docs/", "/docs")]
+    [DataInline("/docs/", "/docs/")]
+    public async Task Swagger_Padded_Prefix_Should_Redirect_To_Document_With_Swagger_Csp(
+        DrnTestContext context, string routePrefix, string requestPath)
+    {
+        context.AddToConfiguration("DrnDevelopmentSettings:SkipValidation", "true");
+        context.AddToConfiguration(CspTestProgram.SwaggerRoutePrefixKey, routePrefix);
+        using var client = await context.ApplicationContext.CreateClientAsync<CspTestProgram>(
+            clientOptions: new() { AllowAutoRedirect = false });
+
+        using var redirect = await client.GetAsync(requestPath);
+        redirect.StatusCode.Should().Be(HttpStatusCode.MovedPermanently);
+        var documentUri = new Uri(new Uri(client.BaseAddress!, requestPath), redirect.Headers.Location!);
+        documentUri.AbsolutePath.Should().Be("/docs/index.html");
+        var csp = redirect.Headers.GetValues("Content-Security-Policy").Single();
+        csp.Split(';', StringSplitOptions.TrimEntries).Should().Contain("style-src 'self' 'unsafe-inline'")
+            .And.Contain("script-src 'self'");
+
+        using var document = await client.GetAsync(documentUri);
+        document.EnsureSuccessStatusCode();
+        (await document.Content.ReadAsStringAsync()).Should().Contain("Custom API docs").And.Contain("swagger-ui-bundle.js");
+        document.Headers.GetValues("Content-Security-Policy").Single().Should().Be(csp);
+    }
+
+    [Theory]
     [DataInline("/swagger/index.html")]
     [DataInline("/docs/swagger/index.html")]
     public async Task Disabled_Swagger_Should_Retain_Default_Csp(DrnTestContext context, string path)

--- a/DRN.Test.Integration/Tests/Framework/Hosting/CspIntegrationTests.cs
+++ b/DRN.Test.Integration/Tests/Framework/Hosting/CspIntegrationTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using DRN.Framework.Hosting.Endpoints;
+using DRN.Test.Utils.Hosting;
+
+namespace DRN.Test.Integration.Tests.Framework.Hosting;
+
+public class CspIntegrationTests
+{
+    [Theory]
+    [DataInline("/swagger/index.html", null, true)]
+    [DataInline("/Swagger/index.html", null, true)]
+    [DataInline("/swagger-ui", null, false)]
+    [DataInline("/docs/swagger", null, false)]
+    [DataInline("/", null, false)]
+    [DataInline("/", CspFor.CspPolicySelf, false)]
+    [DataInline("/", CspFor.CspPolicyInline, false)]
+    [DataInline("/", "unknown-policy", false)]
+    [DataInline("/", "", false)]
+    [DataInline("/", CspFor.CspPolicySwagger, false)]
+    [DataInline("/swagger/policy-probe", CspFor.CspPolicyInline, true)]
+    public async Task Security_Policies_Should_Select_Default_Named_And_Swagger_Policies(
+        DrnTestContext context, string path, string? policyName, bool isSwagger)
+    {
+        context.AddToConfiguration("DrnDevelopmentSettings:SkipValidation", "true");
+        using var client = await context.ApplicationContext.CreateClientAsync<CspTestProgram>();
+        var requestPath = policyName == null ? path : $"{path}?policy={policyName}";
+        using var response = await client.GetAsync(requestPath);
+        response.EnsureSuccessStatusCode();
+        var csp = response.Headers.GetValues("Content-Security-Policy").Single();
+        var styleSrc = csp.Split(';', StringSplitOptions.TrimEntries).Single(value => value.StartsWith("style-src "));
+        var scriptSrc = csp.Split(';', StringSplitOptions.TrimEntries).Single(value => value.StartsWith("script-src "));
+        csp.Split(';', StringSplitOptions.TrimEntries).Should().Contain("default-src 'none'")
+            .And.Contain("object-src 'none'").And.Contain("script-src-attr 'none'");
+
+        if (isSwagger)
+            styleSrc.Should().Be("style-src 'self' 'unsafe-inline'");
+        else
+            styleSrc.Should().Contain("'self'").And.Contain("'nonce-").And.NotContain("'unsafe-inline'");
+
+        if (isSwagger || policyName == CspFor.CspPolicySelf)
+            scriptSrc.Should().Be("script-src 'self'");
+        else if (policyName == CspFor.CspPolicyInline)
+            scriptSrc.Should().Be("script-src 'self' 'unsafe-inline'");
+        else
+        {
+            scriptSrc.Should().StartWith("script-src 'nonce-").And.NotContain("'self'").And.NotContain("'unsafe-inline'");
+            var nonceSource = scriptSrc["script-src ".Length..];
+            styleSrc.Should().Contain(nonceSource);
+        }
+    }
+
+    [Theory]
+    [DataInline]
+    public async Task Named_Swagger_Policy_Replacement_Should_Not_Affect_Other_Policies(DrnTestContext context)
+    {
+        context.AddToConfiguration("DrnDevelopmentSettings:SkipValidation", "true");
+        context.AddToConfiguration(CspTestProgram.ReplaceSwaggerPolicyKey, "true");
+        using var client = await context.ApplicationContext.CreateClientAsync<CspTestProgram>();
+
+        using var swagger = await client.GetAsync("/swagger/index.html");
+        swagger.EnsureSuccessStatusCode();
+        swagger.Headers.GetValues("Content-Security-Policy").Single()
+            .Split(';', StringSplitOptions.TrimEntries).Should().Contain("script-src 'none'");
+
+        using var self = await client.GetAsync($"/?policy={CspFor.CspPolicySelf}");
+        self.EnsureSuccessStatusCode();
+        self.Headers.GetValues("Content-Security-Policy").Single()
+            .Split(';', StringSplitOptions.TrimEntries).Should().Contain("script-src 'self'");
+
+        using var inline = await client.GetAsync($"/?policy={CspFor.CspPolicyInline}");
+        inline.EnsureSuccessStatusCode();
+        inline.Headers.GetValues("Content-Security-Policy").Single()
+            .Split(';', StringSplitOptions.TrimEntries).Should().Contain("script-src 'self' 'unsafe-inline'");
+
+        using var fallback = await client.GetAsync("/");
+        fallback.EnsureSuccessStatusCode();
+        fallback.Headers.GetValues("Content-Security-Policy").Single().Should().Contain("script-src 'nonce-");
+    }
+
+    [Theory]
+    [DataInline("swagger")]
+    [DataInline("docs/swagger")]
+    [DataInline("swagger-ui")]
+    [DataInline("api-docs")]
+    public async Task Swagger_Document_Should_Allow_Inline_Styles_And_Preserve_Caching(DrnTestContext context, string routePrefix)
+    {
+        context.AddToConfiguration("DrnDevelopmentSettings:SkipValidation", "true");
+        context.AddToConfiguration(CspTestProgram.SwaggerRoutePrefixKey, routePrefix);
+        using var client = await context.ApplicationContext.CreateClientAsync<CspTestProgram>();
+        var documentPath = $"/{routePrefix}/index.html";
+        using var first = await client.GetAsync(documentPath);
+        first.EnsureSuccessStatusCode();
+        var html = await first.Content.ReadAsStringAsync();
+        var csp = first.Headers.GetValues("Content-Security-Policy").Single();
+        csp.Split(';', StringSplitOptions.TrimEntries).Should().Contain("style-src 'self' 'unsafe-inline'")
+            .And.Contain("script-src 'self'");
+        html.Should().Contain("Custom API docs").And.Contain("content=\"preserved\"")
+            .And.Contain("swagger-ui-bundle.js").And.NotContain("nonce=").And.NotContain("Reflect.apply");
+        first.Headers.CacheControl!.MaxAge.Should().Be(TimeSpan.FromHours(1));
+        first.Headers.CacheControl.NoStore.Should().BeFalse();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, documentPath);
+        request.Headers.IfNoneMatch.Add(first.Headers.ETag!);
+        using var second = await client.SendAsync(request);
+        second.StatusCode.Should().Be(HttpStatusCode.NotModified);
+        second.Headers.GetValues("Content-Security-Policy").Single().Should().Be(csp);
+
+        const string applicationPath = "/application-page";
+        using var fallback = await client.GetAsync(applicationPath);
+        fallback.EnsureSuccessStatusCode();
+        fallback.Headers.GetValues("Content-Security-Policy").Single().Should()
+            .Contain("script-src 'nonce-").And.Contain("style-src 'self' 'nonce-");
+
+        using var inline = await client.GetAsync($"{applicationPath}?policy={CspFor.CspPolicyInline}");
+        inline.EnsureSuccessStatusCode();
+        inline.Headers.GetValues("Content-Security-Policy").Single().Should()
+            .Contain("script-src 'self' 'unsafe-inline'").And.Contain("style-src 'self' 'nonce-");
+
+        if (routePrefix.Length > 0)
+        {
+            using var outside = await client.GetAsync($"/{routePrefix}-other");
+            outside.EnsureSuccessStatusCode();
+            outside.Headers.GetValues("Content-Security-Policy").Single().Should().Contain("script-src 'nonce-");
+        }
+    }
+
+    [Theory]
+    [DataInline("/swagger/index.html")]
+    [DataInline("/docs/swagger/index.html")]
+    public async Task Disabled_Swagger_Should_Retain_Default_Csp(DrnTestContext context, string path)
+    {
+        context.AddToConfiguration("DrnDevelopmentSettings:SkipValidation", "true");
+        context.AddToConfiguration(CspTestProgram.DisableSwaggerKey, "true");
+        using var client = await context.ApplicationContext.CreateClientAsync<CspTestProgram>();
+        using var response = await client.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        response.Headers.GetValues("Content-Security-Policy").Single().Should()
+            .Contain("script-src 'nonce-").And.Contain("style-src 'self' 'nonce-");
+    }
+}

--- a/DRN.Test.Unit/Tests/Framework/Hosting/DrnProgram/DrnProgramBaseCompositionTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/DrnProgram/DrnProgramBaseCompositionTests.cs
@@ -299,8 +299,9 @@ public class DrnProgramBaseCompositionTests
 
         program.Calls.Should().Equal(
             "headers", "csp", "csp-base", "csp-base",
+            "headers", "csp", "csp-base", "csp-base",
             "headers", "csp", "csp-base", "csp-base");
-        program.Policies.Should().HaveCount(3);
+        program.Policies.Should().HaveCount(4);
         program.Policies.Should().OnlyContain(policy => policy.ContainsKey("X-Program-Customization"));
     }
 

--- a/DRN.Test.Unit/Tests/Framework/Hosting/DrnProgram/DrnProgramSwaggerOptionsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/DrnProgram/DrnProgramSwaggerOptionsTests.cs
@@ -1,0 +1,49 @@
+using DRN.Framework.Hosting.DrnProgram;
+using DRN.Framework.SharedKernel;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace DRN.Test.Unit.Tests.Framework.Hosting.DrnProgram;
+
+public class DrnProgramSwaggerOptionsTests
+{
+    [Theory]
+    [DataInlineUnit(null)]
+    [DataInlineUnit("")]
+    [DataInlineUnit("/")]
+    [DataInlineUnit("///")]
+    public void Swagger_UI_Should_Reject_Empty_Or_Root_Prefixes(string? prefix)
+    {
+        var options = new DrnProgramSwaggerOptions
+        {
+            ConfigureSwaggerUIOptionsAction = ui => ui.RoutePrefix = prefix!
+        };
+
+        Action configure = () => options.ConfigureSwaggerUI(new SwaggerUIOptions());
+
+        configure.Should().Throw<ConfigurationException>().WithMessage("*RoutePrefix must be nonempty*");
+        options.SwaggerUIPathPrefix.Should().BeNull();
+    }
+
+    [Theory]
+    [DataInlineUnit("swagger")]
+    [DataInlineUnit("docs/Swagger")]
+    [DataInlineUnit("swagger-ui")]
+    [DataInlineUnit("api-docs")]
+    public void Swagger_UI_Should_Use_Validated_Prefix_After_One_Callback(string prefix)
+    {
+        var calls = 0;
+        var options = new DrnProgramSwaggerOptions
+        {
+            ConfigureSwaggerUIOptionsAction = ui =>
+            {
+                calls++;
+                ui.RoutePrefix = prefix;
+            }
+        };
+
+        options.ConfigureSwaggerUI(new SwaggerUIOptions());
+
+        calls.Should().Be(1);
+        options.SwaggerUIPathPrefix!.Value.Value.Should().Be("/" + prefix);
+    }
+}

--- a/DRN.Test.Unit/Tests/Framework/Hosting/DrnProgram/DrnProgramSwaggerOptionsTests.cs
+++ b/DRN.Test.Unit/Tests/Framework/Hosting/DrnProgram/DrnProgramSwaggerOptionsTests.cs
@@ -25,11 +25,14 @@ public class DrnProgramSwaggerOptionsTests
     }
 
     [Theory]
-    [DataInlineUnit("swagger")]
-    [DataInlineUnit("docs/Swagger")]
-    [DataInlineUnit("swagger-ui")]
-    [DataInlineUnit("api-docs")]
-    public void Swagger_UI_Should_Use_Validated_Prefix_After_One_Callback(string prefix)
+    [DataInlineUnit("swagger", "swagger")]
+    [DataInlineUnit("docs/Swagger", "docs/Swagger")]
+    [DataInlineUnit("swagger-ui", "swagger-ui")]
+    [DataInlineUnit("api-docs", "api-docs")]
+    [DataInlineUnit("/docs", "docs")]
+    [DataInlineUnit("docs/", "docs")]
+    [DataInlineUnit("/docs/", "docs")]
+    public void Swagger_UI_Should_Use_Validated_Prefix_After_One_Callback(string prefix, string expectedPrefix)
     {
         var calls = 0;
         var options = new DrnProgramSwaggerOptions
@@ -41,9 +44,11 @@ public class DrnProgramSwaggerOptionsTests
             }
         };
 
-        options.ConfigureSwaggerUI(new SwaggerUIOptions());
+        var uiOptions = new SwaggerUIOptions();
+        options.ConfigureSwaggerUI(uiOptions);
 
         calls.Should().Be(1);
-        options.SwaggerUIPathPrefix!.Value.Value.Should().Be("/" + prefix);
+        uiOptions.RoutePrefix.Should().Be(expectedPrefix);
+        options.SwaggerUIPathPrefix!.Value.Value.Should().Be("/" + expectedPrefix);
     }
 }

--- a/DRN.Test.Utils/Hosting/AppSettingsLifecycleTestPrograms.cs
+++ b/DRN.Test.Utils/Hosting/AppSettingsLifecycleTestPrograms.cs
@@ -116,7 +116,7 @@ public sealed class StartupExceptionReportProgram : DrnProgramBase<StartupExcept
             throw StartupFailure;
 
         if (ReportFailureMode == "builder")
-            throw new ApplicationException("Report builder failure.");
+            throw new InvalidOperationException("Report builder failure.");
 
         builder.Services.AddSingleton<StartupExceptionReportDisposable>();
         builder.Services.AddSingleton<StartupExceptionReportAsyncDisposable>();
@@ -142,7 +142,7 @@ public sealed class StartupExceptionReportExceptionHandler : IDrnExceptionHandle
         _ = serviceProvider.GetRequiredService<StartupExceptionReportAsyncDisposable>();
 
         if (StartupExceptionReportProgram.ReportFailureMode is "generation" or "both")
-            return Task.FromException<ExceptionContentResult?>(new ApplicationException("Report generation failure."));
+            return Task.FromException<ExceptionContentResult?>(new InvalidOperationException("Report generation failure."));
 
         return Task.FromResult<ExceptionContentResult?>(null);
     }
@@ -155,7 +155,7 @@ public sealed class StartupExceptionReportAsyncDisposable : IAsyncDisposable
         await Task.Yield();
         StartupExceptionReportProgram.AsyncDisposalCompleted = true;
         if (StartupExceptionReportProgram.ReportFailureMode is "disposal" or "both")
-            throw new ApplicationException("Report disposal failure.");
+            throw new InvalidOperationException("Report disposal failure.");
     }
 }
 

--- a/DRN.Test.Utils/Hosting/Auth/AuthenticationConfigurationTestProgram.cs
+++ b/DRN.Test.Utils/Hosting/Auth/AuthenticationConfigurationTestProgram.cs
@@ -53,9 +53,9 @@ public sealed class AuthenticationConfigurationTestProgram : DrnProgramBase<Auth
         options.AddSwagger = false;
     }
 
-    protected override void ConfigureDefaultSecurityHeaders(HeaderPolicyCollection policies, IServiceProvider services, IAppSettings appSettings)
+    protected override void ConfigureDefaultSecurityHeaders(HeaderPolicyCollection policies, IServiceProvider serviceProvider, IAppSettings appSettings)
     {
-        base.ConfigureDefaultSecurityHeaders(policies, services, appSettings);
+        base.ConfigureDefaultSecurityHeaders(policies, serviceProvider, appSettings);
         policies.AddCustomHeader("X-Program-Customization", "preserved");
     }
 

--- a/DRN.Test.Utils/Hosting/CspTestProgram.cs
+++ b/DRN.Test.Utils/Hosting/CspTestProgram.cs
@@ -1,0 +1,69 @@
+using DRN.Framework.Hosting.DrnProgram;
+using DRN.Framework.Hosting.Endpoints;
+using DRN.Framework.Utils.Logging;
+using DRN.Framework.Utils.Settings;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace DRN.Test.Utils.Hosting;
+
+public sealed class CspTestProgram : DrnProgramBase<CspTestProgram>, IDrnProgram
+{
+    public const string ReplaceSwaggerPolicyKey = "CspTest:ReplaceSwaggerPolicy";
+    public const string SwaggerRoutePrefixKey = "CspTest:SwaggerRoutePrefix";
+    public const string DisableSwaggerKey = "CspTest:DisableSwagger";
+
+    public static async Task Main(string[] args) => await RunAsync(args);
+
+    protected override Task AddServicesAsync(WebApplicationBuilder builder, IAppSettings appSettings, IScopedLog scopedLog)
+    {
+        builder.Services.AddAuthentication().AddCookie();
+        return Task.CompletedTask;
+    }
+
+    protected override void ConfigureIdentityRenewal(IServiceCollection services, IAppSettings appSettings)
+    {
+        // This host tests CSP and does not use Identity cookie renewal.
+    }
+
+    protected override void ConfigureSwaggerOptions(DrnProgramSwaggerOptions options, IAppSettings appSettings)
+    {
+        base.ConfigureSwaggerOptions(options, appSettings);
+        options.AddSwagger = !appSettings.Configuration.GetValue<bool>(DisableSwaggerKey);
+        options.ConfigureSwaggerUIOptionsAction = ui =>
+        {
+            ui.RoutePrefix = appSettings.Configuration[SwaggerRoutePrefixKey] ?? ui.RoutePrefix;
+            ui.DocumentTitle = "Custom API docs";
+            ui.HeadContent = "<meta name=\"custom\" content=\"preserved\">";
+            ui.CacheLifetime = TimeSpan.FromHours(1);
+        };
+    }
+
+    protected override void ConfigureSecurityHeaderPolicyBuilder(
+        SecurityHeaderPolicyBuilder builder, IServiceProvider serviceProvider, IAppSettings appSettings)
+    {
+        base.ConfigureSecurityHeaderPolicyBuilder(builder, serviceProvider, appSettings);
+        if (!appSettings.Configuration.GetValue<bool>(ReplaceSwaggerPolicyKey)) return;
+
+        var replacement = new HeaderPolicyCollection();
+        ConfigureDefaultSecurityHeaders(replacement, serviceProvider, appSettings);
+        replacement.Remove("Content-Security-Policy");
+        replacement.AddContentSecurityPolicy(csp =>
+        {
+            ConfigureDefaultCspBase(csp);
+            csp.AddScriptSrc().None();
+        });
+        builder.AddPolicy(CspFor.CspPolicySwagger, replacement);
+    }
+
+    protected override void MapApplicationEndpoints(WebApplication application, IAppSettings appSettings)
+    {
+        base.MapApplicationEndpoints(application, appSettings);
+        // Anonymous metadata also lets Swagger middleware serve its document through the normal pipeline.
+        application.MapGet("/{**path}", (HttpContext context) =>
+        {
+            if (context.Request.Query.TryGetValue("policy", out var policy))
+                context.Items[CspFor.CspPolicyName] = policy.ToString();
+            return Results.Content("<html></html>", "text/html");
+        }).AllowAnonymous();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated security policy for Swagger UI, supporting inline SVG styles and same-origin scripts.
  - Swagger requests now receive the Swagger-specific policy based on the configured route prefix, with case-insensitive, segment-aware matching.
  - Swagger route prefixes are normalized and validated at startup; empty or root-only prefixes are rejected.

- **Bug Fixes**
  - Improved separation between Swagger and application security policies.
  - Preserved default security policies when Swagger is disabled.

- **Documentation**
  - Documented Swagger route-prefix validation and security-header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->